### PR TITLE
Implement new dropout scheme for GRU

### DIFF
--- a/tests/nnet/test_gru.py
+++ b/tests/nnet/test_gru.py
@@ -183,7 +183,7 @@ def test_gru_backward(data):
                   label="X")
     T, N, C = X.shape
     D = data.draw(st.sampled_from(list(range(1, 5))), label="D")
-    dropout = data.draw(st.sampled_from([0.45]), label="dropout")  # TODO: RESTORE DROPOUT
+    dropout = data.draw(st.sampled_from([0, 0.45]), label="dropout")  # TODO: RESTORE DROPOUT
 
 
     Wz = data.draw(hnp.arrays(shape=(D, D),


### PR DESCRIPTION
This updated dropout scheme should allow the gru to be much more effective, especially on smaller datasets.

Following the dropout scheme specified in `[1]`, the hidden-hidden weights (Wz/Wr/Wh)
randomly have their weights dropped prior to forward/back-prop. The input connections
(via Uz/Ur/Uh) have variational dropout (`[2]`) applied to them with a common dropout
mask across all t. That is three static dropout masks, each with shape-(N,D), are
applied to

                                      X_{t} Uz
                                      X_{t} Ur
                                      X_{t} Uh
respectively, for all t.

References
----------
.. [1] S. Merity, et. al. "Regularizing and Optimizing LSTM Language Models",
       arXiv:1708.02182v1, 2017.

.. [2] Y. Gal, Z. Ghahramani "A Theoretically Grounded Application of Dropout
       in Recurrent Neural Networks" arXiv:1512.05287v5, 2016.