### PR TITLE
Einsum opt

### DIFF
--- a/mygrad/linalg/ops.py
+++ b/mygrad/linalg/ops.py
@@ -248,7 +248,6 @@ class EinSum(BroadcastableOp):
             dfdx *= factor
         return dfdx
 
-
     def backward(self, grad, *, graph, **kwargs):
         """ Back-propagates the gradient through all of the operation's inputs.
             Constant tensors do not propagate a gradient.

--- a/mygrad/linalg/ops.py
+++ b/mygrad/linalg/ops.py
@@ -252,6 +252,12 @@ class EinSum(BroadcastableOp):
         """ Back-propagates the gradient through all of the operation's inputs.
             Constant tensors do not propagate a gradient.
 
+            This implementation of ``backward` is specialized such that
+            `` self.backward_var`` can return ``None`` to bypass a
+            gradient-accumulation step.
+
+            Parameters
+            ----------
             grad : numpy.ndarray
                 The back-propagated total derivative with respect to the present
                 operation (`f`): d(out)/df

--- a/mygrad/linalg/ops.py
+++ b/mygrad/linalg/ops.py
@@ -142,7 +142,7 @@ class EinSum(BroadcastableOp):
         self.variables = variables
         self.optimize = optimize
 
-        self.cache = Counter(zip(variables, in_lbls))
+        self.cache = Counter(zip(variables, self.in_lbls))
         return np.einsum("->".join((in_lbls, out_lbls)), *(var.data for var in self.variables),
                          optimize=optimize)
 
@@ -163,10 +163,10 @@ class EinSum(BroadcastableOp):
         var = self.variables[index]
 
         factor = self.cache[(var, original_var_lbl)]
-        self.cache[(var, original_var_lbl)] = 0
-
         if factor == 0:
             return np.zeros_like(var.data)
+
+        self.cache[(var, original_var_lbl)] = 0
 
         var_lbl = _unique_from_end(original_var_lbl)
         repeat_lbls = len(var_lbl) != len(original_var_lbl)

--- a/tests/linalg/test_einsum.py
+++ b/tests/linalg/test_einsum.py
@@ -246,6 +246,18 @@ def test_redundant_args():
     a = Tensor(np.arange(4).reshape(2, 2))
     a_copy = copy(a)
 
+    # check matmul (no redundant indices)
+    o = einsum("ij,jk", a, a)
+    assert len(o.creator.cache) == 2
+    o.sum().backward()
+
+    o = a_copy @ a_copy
+    o.sum().backward()
+    assert_allclose(a.grad, a_copy.grad)
+
+    a = Tensor(np.arange(4).reshape(2, 2))
+    a_copy = copy(a)
+
     # check traces
     o = einsum("ii,ii", a, a)
     assert len(o.creator.cache) == 1


### PR DESCRIPTION
Back-propagation via `einsum` is optimized such that any tensor that occurs
redundantly within the summation will only have its gradient computed once.
This optimization accommodates all number and combination of redundancies that can
be encountered.

E.g. back-propping through `einsum('..., ...->', x, x)` will only incur a single
computation/accumulation for `x.grad` rather than two. This permits users to
leverage the efficiency of sum-reduction, where `(x ** 2).sum()` is sub-optimal,
without being penalized during back-propagation.