### PR TITLE
Argmin/max and test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.ipynb
 .vscode
 .pytest_cache
+**.DS_Store

--- a/mygrad/__init__.py
+++ b/mygrad/__init__.py
@@ -5,6 +5,7 @@ from mygrad.math.trigonometric.funcs import *
 from mygrad.math.hyperbolic_trig.funcs import *
 from mygrad.math.sequential.funcs import *
 from mygrad.math.sequential.funcs import max, min
+from mygrad.math.nondifferentiable import argmax, argmin
 from mygrad.math.misc.funcs import *
 from mygrad.tensor_manip.array_shape.funcs import *
 from mygrad.tensor_manip.transpose_like.funcs import *
@@ -19,6 +20,7 @@ __version__ = "0.6"
 for attr in (sum, prod, cumprod, cumsum,
              mean, std, var,
              max, min,
+             argmax, argmin,
              swapaxes, transpose, moveaxis,
              reshape, squeeze,
              matmul):

--- a/mygrad/math/nondifferentiable.py
+++ b/mygrad/math/nondifferentiable.py
@@ -1,4 +1,5 @@
 import numpy as np
+from mygrad.tensor_base import Tensor
 
 __all__ = ["argmin",
            "argmax"]
@@ -8,7 +9,7 @@ def argmax(a, axis=None, out=None):
 
         Parameters
         ----------
-        a: mygrad.Tensor
+        a: array_like
         
         axis: int, optional
             By default, the index is into the flattened array, otherwise along the specified axis.
@@ -19,15 +20,16 @@ def argmax(a, axis=None, out=None):
         Returns
         -------
         numpy.ndarray[int]"""
-    
-    return np.argmax(a.data, axis, out)
+        
+    a = a.data if isinstance(a, Tensor) else a
+    return np.argmax(a, axis, out)
     
 def argmin(a, axis=None, out=None):
     """ Returns the indices of the minimum values along an axis.
 
         Parameters
         ----------
-        a: mygrad.Tensor
+        a: array_like
         
         axis: int, optional
             By default, the index is into the flattened array, otherwise along the specified axis.
@@ -38,5 +40,6 @@ def argmin(a, axis=None, out=None):
         Returns
         -------
         numpy.ndarray[int]"""
-    
-    return np.argmin(a.data, axis, out)
+
+    a = a.data if isinstance(a, Tensor) else a
+    return np.argmin(a, axis, out)

--- a/mygrad/math/nondifferentiable.py
+++ b/mygrad/math/nondifferentiable.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+__all__ = ["argmin",
+           "argmax"]
+
+def argmax(a, axis=None, out=None):
+    """ Returns the indices of the maximum values along an axis.
+
+        Parameters
+        ----------
+        a: mygrad.Tensor
+        
+        axis: int, optional
+            By default, the index is into the flattened array, otherwise along the specified axis.
+        
+        out: numpy.array, optional
+            If provided, the result will be inserted into this array. It should be of the appropriate shape and dtype.
+        
+        Returns
+        -------
+        numpy.ndarray[int]"""
+    
+    return np.argmax(a.data, axis, out)
+    
+def argmin(a, axis=None, out=None):
+    """ Returns the indices of the minimum values along an axis.
+
+        Parameters
+        ----------
+        a: mygrad.Tensor
+        
+        axis: int, optional
+            By default, the index is into the flattened array, otherwise along the specified axis.
+        
+        out: numpy.array, optional
+            If provided, the result will be inserted into this array. It should be of the appropriate shape and dtype.
+        
+        Returns
+        -------
+        numpy.ndarray[int]"""
+    
+    return np.argmin(a.data, axis, out)

--- a/tests/math/unary/test_nondifferentiable.py
+++ b/tests/math/unary/test_nondifferentiable.py
@@ -1,4 +1,4 @@
-from mygrad import argmin, argmax
+from mygrad as mg
 from mygrad.tensor_base import Tensor
 
 import hypothesis.strategies as st
@@ -14,18 +14,34 @@ import numpy as np
 dtype_strat_numpy = st.sampled_from((np.int8, np.int16, np.int32, np.int64,
                                      np.float16, np.float32, np.float64))
 
+
 @given(a=hnp.arrays(shape=hnp.array_shapes(max_side=4, max_dims=5),
                     dtype=dtype_strat_numpy),
        data=st.data())
 def test_argmin(a, data):
     axis = data.draw(valid_axes(ndim=a.ndim, single_axis_only=True), label="axis")
-
-    assert_allclose(Tensor(a).argmin(axis=axis), a.argmin(axis=axis))
+    tensor = Tensor(a)
+    # tensor input
+    assert_allclose(mg.argmin(tensor), np.argmin(a, axis=axis))
+    
+    # tensor method
+    assert_allclose(tensor.argmin(axis=axis), a.argmin(axis=axis))
+    
+    # array input
+    assert_allclose(mg.argmin(a, axis=axis), np.argmin(a, axis=axis))
 
 @given(a=hnp.arrays(shape=hnp.array_shapes(max_side=4, max_dims=5),
                     dtype=dtype_strat_numpy),
        data=st.data())
 def test_argmax(a, data):
     axis = data.draw(valid_axes(ndim=a.ndim, single_axis_only=True), label="axis")
+    tensor = Tensor(a)
     
-    assert_allclose(Tensor(a).argmax(axis=axis), a.argmax(axis=axis))
+    # tensor input
+    assert_allclose(mg.argmax(tensor), np.argmax(a, axis=axis))
+    
+    # tensor method
+    assert_allclose(tensor.argmax(axis=axis), a.argmax(axis=axis))
+    
+    # array input
+    assert_allclose(mg.argmax(a, axis=axis), np.argmax(a, axis=axis))

--- a/tests/math/unary/test_nondifferentiable.py
+++ b/tests/math/unary/test_nondifferentiable.py
@@ -2,24 +2,30 @@ from mygrad import argmin, argmax
 from mygrad.tensor_base import Tensor
 
 import hypothesis.strategies as st
-from numpy.testing import assert_equal
+from numpy.testing import assert_allclose
 import numpy as np
+
+from ...custom_strategies import valid_axes
 from hypothesis import given
+import hypothesis.extra.numpy as hnp
 
 import numpy as np
 
-@given(d=st.integers(min_value=3, max_value=10))
-def test_argmin(d):
-    dimensions = tuple(np.random.randint(1,6) for i in range(d)) 
+dtype_strat_numpy = st.sampled_from((np.int8, np.int16, np.int32, np.int64,
+                                     np.float16, np.float32, np.float64))
 
-    a = np.random.randint(-100,100, size=dimensions)
-    axis = np.random.randint(0,d-1)
-    assert_equal(Tensor(a).argmin(axis=axis), a.argmin(axis=axis))
+@given(a=hnp.arrays(shape=hnp.array_shapes(max_side=4, max_dims=5),
+                    dtype=dtype_strat_numpy),
+       data=st.data())
+def test_argmin(a, data):
+    axis = data.draw(valid_axes(ndim=a.ndim, single_axis_only=True), label="axis")
 
-@given(d=st.integers(min_value=3, max_value=10))
-def test_argmax(d):
-    dimensions = tuple(np.random.randint(1,6) for i in range(d)) 
+    assert_allclose(Tensor(a).argmin(axis=axis), a.argmin(axis=axis))
 
-    a = np.random.randint(-100,100, size=dimensions)
-    axis = np.random.randint(0,d-1)
-    assert_equal(Tensor(a).argmax(axis=axis), a.argmax(axis=axis))
+@given(a=hnp.arrays(shape=hnp.array_shapes(max_side=4, max_dims=5),
+                    dtype=dtype_strat_numpy),
+       data=st.data())
+def test_argmax(a, data):
+    axis = data.draw(valid_axes(ndim=a.ndim, single_axis_only=True), label="axis")
+    
+    assert_allclose(Tensor(a).argmax(axis=axis), a.argmax(axis=axis))

--- a/tests/math/unary/test_nondifferentiable.py
+++ b/tests/math/unary/test_nondifferentiable.py
@@ -1,0 +1,25 @@
+from mygrad import argmin, argmax
+from mygrad.tensor_base import Tensor
+
+import hypothesis.strategies as st
+from numpy.testing import assert_equal
+import numpy as np
+from hypothesis import given
+
+import numpy as np
+
+@given(d=st.integers(min_value=3, max_value=10))
+def test_argmin(d):
+    dimensions = tuple(np.random.randint(1,6) for i in range(d)) 
+
+    a = np.random.randint(-100,100, size=dimensions)
+    axis = np.random.randint(0,d-1)
+    assert_equal(Tensor(a).argmin(axis=axis), a.argmin(axis=axis))
+
+@given(d=st.integers(min_value=3, max_value=10))
+def test_argmax(d):
+    dimensions = tuple(np.random.randint(1,6) for i in range(d)) 
+
+    a = np.random.randint(-100,100, size=dimensions)
+    axis = np.random.randint(0,d-1)
+    assert_equal(Tensor(a).argmax(axis=axis), a.argmax(axis=axis))


### PR DESCRIPTION
See the changes made as outlined [here](https://github.com/rsokl/MyGrad/issues/58#issue-333017179). I did not support numpy's `array_like` in my implementation since `mygrad.argmin` and `mygrad.argmax` are mainly used as methods, and users should simply opt for numpy's methods to do the same operations to non-Tensors. I ran my own test codes and did some simple manual testing. Everything seems to be in working order. 

Also, added mac compatibility to the gitignore file. 