### PR TITLE
Tensor manipulation routines (addresses #90)

### DIFF
--- a/mygrad/tensor_base.py
+++ b/mygrad/tensor_base.py
@@ -11,6 +11,7 @@ from mygrad.tensor_manip.transpose_like.ops import Tensor_Transpose_Property
 from mygrad.tensor_core_ops.indexing import GetItem, SetItem
 from mygrad.linalg.ops import MatMul
 from mygrad.operation_base import Operation, BroadcastableOp
+from mygrad.tensor_manip.array_shape.ops import Ravel
 
 import numpy as np
 from typing import Union, Set, Type, List
@@ -565,6 +566,22 @@ class Tensor:
         if self.size > 1:
             raise TypeError("can only convert a tensor of size 1 to a Python scalar")
         return int(self.data)
+
+    def flatten(self):
+        """ Flattens contents of the tensor into a contiguous 1-D array.
+
+        Returns
+        -------
+        mygrad.Tensor
+
+        Examples
+        --------
+        >>> import mygrad as mg
+        >>> x = mg.Tensor([[1, 2], [3, 4]])
+        >>> mg.ravel(x)
+        Tensor([1, 2, 3, 4])
+        """
+        return Tensor._op(Ravel, self, constant=self.constant)
 
     @property
     def size(self):

--- a/mygrad/tensor_manip/array_shape/funcs.py
+++ b/mygrad/tensor_manip/array_shape/funcs.py
@@ -1,8 +1,8 @@
-from .ops import Reshape, Squeeze, Ravel
+from .ops import *
 from mygrad.tensor_base import Tensor
 
 
-__all__ = ["reshape", "squeeze", "ravel"]
+__all__ = ["reshape", "squeeze", "ravel", "expand_dims"]
 
 
 def reshape(a, *newshape, constant=False):
@@ -131,3 +131,39 @@ def ravel(a, constant=False):
     Tensor([1, 2, 3, 4])
     """
     return Tensor._op(Ravel, a, constant=constant)
+
+
+def expand_dims(a, axis, constant=False):
+    """
+    Expand the dimensions of a tensor by adding a new axis.
+
+    Parameters
+    ----------
+    a : array_like
+        The tensor to be expanded
+
+    axis : int
+        The position of the new axis in the expanded array shape.
+
+    constant : bool, optional(default=False)
+        If ``True``, the returned tensor is a constant (it
+        does not back-propagate a gradient)
+
+    Returns
+    -------
+    mygrad.Tensor
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> x = mg.Tensor([1, 2])
+    >>> x.shape
+    (2,)
+    >>> y = mg.expand_dims(x, 1)
+    >>> y.shape
+    (2, 1)
+    >>> z = mg.expand_dims(y, 0)
+    >>> z.shape
+    (1, 2, 1)
+    """
+    return Tensor._op(ExpandDims, a, op_args=(axis,), constant=constant)

--- a/mygrad/tensor_manip/array_shape/funcs.py
+++ b/mygrad/tensor_manip/array_shape/funcs.py
@@ -2,7 +2,7 @@ from .ops import *
 from mygrad.tensor_base import Tensor
 
 
-__all__ = ["reshape", "squeeze", "ravel", "expand_dims"]
+__all__ = ["reshape", "squeeze", "ravel", "expand_dims", "broadcast_to"]
 
 
 def reshape(a, *newshape, constant=False):
@@ -167,3 +167,54 @@ def expand_dims(a, axis, constant=False):
     (1, 2, 1)
     """
     return Tensor._op(ExpandDims, a, op_args=(axis,), constant=constant)
+
+
+def broadcast_to(a, *newshape, constant=False):
+    """
+    Broadcast a tensor to a new shape.
+
+    Parameters
+    ----------
+    a : array_like
+        The tensor to be broadcasted
+
+    *newshape: Union[int, Tuple[int, ...]]
+        The shape of the broadcasted tensor. This shape
+        should be broadcast-compatible with the original
+        shape.
+
+    constant : bool, optional(default=False)
+        If ``True``, the returned tensor is a constant (it
+        does not back-propagate a gradient)
+
+    Returns
+    -------
+    mygrad.Tensor
+
+    Raises
+    ------
+    ValueError
+        If the array is not compatible with the new shape
+        according to Numpy's broadcasting rules.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> x = mg.Tensor([1, 2, 3])
+    >>> mg.broadcast_to(x, (3,3))
+    Tensor([[1, 2, 3],
+            [1, 2, 3],
+            [1, 2, 3]])
+    >>> mg.broadcast_to(x, (4,4))
+    Traceback (most recent call last):
+    ...
+    ValueError: operands could not be broadcast together with remapped
+    shapes [original->remapped]: (3,) and requested shape (4,4)
+    """
+    if not newshape:
+        raise TypeError("reshape() takes at least 1 argument (0 given)")
+    if hasattr(newshape[0], "__iter__"):
+        if len(newshape) > 1:
+            raise TypeError("an integer is required")
+        newshape = newshape[0]
+    return Tensor._op(BroadcastTo, a, op_args=(newshape,), constant=constant)

--- a/mygrad/tensor_manip/array_shape/funcs.py
+++ b/mygrad/tensor_manip/array_shape/funcs.py
@@ -1,8 +1,8 @@
-from .ops import Reshape, Squeeze
+from .ops import Reshape, Squeeze, Ravel
 from mygrad.tensor_base import Tensor
 
 
-__all__ = ["reshape", "squeeze"]
+__all__ = ["reshape", "squeeze", "ravel"]
 
 
 def reshape(a, *newshape, constant=False):
@@ -98,3 +98,36 @@ def squeeze(a, axis=None, constant=False):
     >>> mg.squeeze(x, axis=2).shape
     (1, 3)"""
     return Tensor._op(Squeeze, a, op_args=(axis,), constant=constant)
+
+
+def ravel(a, constant=False):
+    """
+    Flattens contents of a tensor into a contiguous 1-D array.
+
+    Parameters
+    ----------
+    a : array_like
+        The tensor to be flattened
+
+    constant : bool, optional(default=False)
+        If ``True``, the returned tensor is a constant (it
+        does not back-propagate a gradient)
+
+    Returns
+    -------
+    mygrad.Tensor
+
+    Notes
+    -----
+    ``ravel`` utilizes C-ordering, meaning that it reads & writes elements using
+    C-like index ordering; the last axis index changing fastest, and, proceeding
+    in reverse order, the first axis index changing slowest.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> x = mg.Tensor([[1, 2], [3, 4]])
+    >>> mg.ravel(x)
+    Tensor([1, 2, 3, 4])
+    """
+    return Tensor._op(Ravel, a, constant=constant)

--- a/mygrad/tensor_manip/array_shape/ops.py
+++ b/mygrad/tensor_manip/array_shape/ops.py
@@ -1,7 +1,7 @@
 from mygrad.operation_base import Operation
 import numpy as np
 
-__all__ = ["Reshape", "Squeeze"]
+__all__ = ["Reshape", "Squeeze", "Ravel"]
 
 
 class Reshape(Operation):
@@ -26,6 +26,19 @@ class Squeeze(Operation):
         self.variables = (a,)
         return np.squeeze(a.data, axis=axis)
     
+    def backward_var(self, grad, index, **kwargs):
+        a = self.variables[index]
+        return grad.reshape(a.shape)
+
+
+class Ravel(Operation):
+    def __call__(self, a):
+        """ Parameters
+            ----------
+            a : mygrad.Tensor"""
+        self.variables = (a,)
+        return np.ravel(a.data, order='C')
+
     def backward_var(self, grad, index, **kwargs):
         a = self.variables[index]
         return grad.reshape(a.shape)

--- a/mygrad/tensor_manip/array_shape/ops.py
+++ b/mygrad/tensor_manip/array_shape/ops.py
@@ -1,7 +1,7 @@
 from mygrad.operation_base import Operation
 import numpy as np
 
-__all__ = ["Reshape", "Squeeze", "Ravel"]
+__all__ = ["Reshape", "Squeeze", "Ravel", "ExpandDims"]
 
 
 class Reshape(Operation):
@@ -38,6 +38,20 @@ class Ravel(Operation):
             a : mygrad.Tensor"""
         self.variables = (a,)
         return np.ravel(a.data, order='C')
+
+    def backward_var(self, grad, index, **kwargs):
+        a = self.variables[index]
+        return grad.reshape(a.shape)
+
+
+class ExpandDims(Operation):
+    def __call__(self, a, axis):
+        """ Parameters
+            ----------
+            a : mygrad.Tensor
+            axis : int """
+        self.variables = (a,)
+        return np.expand_dims(a.data, axis=axis)
 
     def backward_var(self, grad, index, **kwargs):
         a = self.variables[index]

--- a/mygrad/tensor_manip/array_shape/ops.py
+++ b/mygrad/tensor_manip/array_shape/ops.py
@@ -1,7 +1,8 @@
 from mygrad.operation_base import Operation
+from mygrad._utils import reduce_broadcast
 import numpy as np
 
-__all__ = ["Reshape", "Squeeze", "Ravel", "ExpandDims"]
+__all__ = ["Reshape", "Squeeze", "Ravel", "ExpandDims", "BroadcastTo"]
 
 
 class Reshape(Operation):
@@ -56,3 +57,17 @@ class ExpandDims(Operation):
     def backward_var(self, grad, index, **kwargs):
         a = self.variables[index]
         return grad.reshape(a.shape)
+
+
+class BroadcastTo(Operation):
+    def __call__(self, a, shape):
+        """ Parameters
+            ----------
+            a : mygrad.Tensor
+            shape : Tuple[int, ...]"""
+        self.variables = (a,)
+        return np.broadcast_to(a.data, shape=shape)
+
+    def backward_var(self, grad, index, **kwargs):
+        a = self.variables[index]
+        return reduce_broadcast(grad, a.shape)


### PR DESCRIPTION
This adds the four tensor manipulation routines detailed in #90. We may want to mention somewhere the deprecated behavior of `np.expand_dims` for axis values far outside the shape:

>Note: Previous to NumPy 1.13.0, neither axis < -a.ndim - 1 nor axis > a.ndim raised errors or put the new axis where documented. Those axis values are now deprecated and will raise an AxisError in the future.

I didn't know where to mention this, so that may be worth looking at. One other small issue: since all of these functions directly wrap numpy, I copied text from the numpy documentation for some of the docstrings. Are there any plagiarism concerns with this?