### PR TITLE
fix backwards inequality for einsum-opt test

### DIFF
--- a/tests/linalg/test_einsum.py
+++ b/tests/linalg/test_einsum.py
@@ -19,7 +19,7 @@ def bool_strat():
     """ einsum's optimize=True option has bugs prior to version 1.14.5
         (caught by these very unit tests!), thus we only test `optimize=True`
         for more recent versions."""
-    return st.booleans() if np.__version__ <= "1.14.5" else st.just(False)
+    return st.booleans() if np.__version__ >= "1.14.5" else st.just(False)
 
 
 def compare_einsum(*operands, optimize=False):

--- a/tests/nnet/test_gru.py
+++ b/tests/nnet/test_gru.py
@@ -17,12 +17,12 @@ from tests.utils import does_not_raise
 @settings(deadline=None)
 @given(
     s0=st.none()
-    | hnp.arrays(shape=(1, 2), dtype=float, elements=st.floats())
-    | hnp.arrays(shape=(1, 2), dtype=float, elements=st.floats()).map(
-        lambda x: Tensor(x, constant=True)
-    )
-    | hnp.arrays(shape=(1, 2), dtype=float, elements=st.floats()).map(
+    | hnp.arrays(shape=(1, 2), dtype=float, elements=st.just(0))
+    | hnp.arrays(shape=(1, 2), dtype=float, elements=st.just(0)).map(
         lambda x: Tensor(x)
+    )
+    | hnp.arrays(shape=(1, 2), dtype=float, elements=st.just(0)).map(
+        lambda x: Tensor(x, constant=True)
     ),
     dropout=st.floats(0, 1),
     out_constant=st.booleans(),


### PR DESCRIPTION
Closes #178 

Thank you @Zac-HD for catching this! I don't have a job that runs against old NumPy