### PR TITLE
Fix sigmoid, add test

### DIFF
--- a/src/mygrad/nnet/activations/sigmoid.py
+++ b/src/mygrad/nnet/activations/sigmoid.py
@@ -7,7 +7,7 @@ from mygrad.tensor_base import Tensor
 class Sigmoid(Operation):
     def __call__(self, a):
         self.variables = (a,)
-        x = -1.0 * a.data
+        x = np.asarray(-1.0 * a.data)
         np.exp(x, out=x)
         x += 1
         np.reciprocal(x, out=x)

--- a/src/mygrad/nnet/activations/sigmoid.py
+++ b/src/mygrad/nnet/activations/sigmoid.py
@@ -7,7 +7,7 @@ from mygrad.tensor_base import Tensor
 class Sigmoid(Operation):
     def __call__(self, a):
         self.variables = (a,)
-        x = np.asarray(-1.0 * a.data)
+        x = -1.0 * a.data
         np.exp(x, out=x)
         x += 1
         np.reciprocal(x, out=x)

--- a/tests/nnet/activations/test_sigmoid.py
+++ b/tests/nnet/activations/test_sigmoid.py
@@ -17,7 +17,7 @@ def _not_large(*arrs, **kwargs):
 
 
 @backprop_test_factory(
-    mygrad_func=sigmoid, true_func=lambda x: 1 / (1 + np.exp(-x)), num_arrays=1, assumptions=_not_large
+    mygrad_func=sigmoid, true_func=lambda x: 1 / (1 + np.exp(-x)), num_arrays=1, index_to_bnds={0: (-500, 500)},
 )
 def test_sigmoid_bkwd():
     pass

--- a/tests/nnet/activations/test_sigmoid.py
+++ b/tests/nnet/activations/test_sigmoid.py
@@ -11,11 +11,6 @@ def test_sigmoid_fwd():
     pass
 
 
-def _not_large(*arrs, **kwargs):
-    x = arrs[0]
-    return np.all(np.abs(x.data) < 500)
-
-
 @backprop_test_factory(
     mygrad_func=sigmoid, true_func=lambda x: 1 / (1 + np.exp(-x)), num_arrays=1, index_to_bnds={0: (-500, 500)},
 )

--- a/tests/nnet/activations/test_sigmoid.py
+++ b/tests/nnet/activations/test_sigmoid.py
@@ -1,0 +1,23 @@
+import numpy as np
+
+from mygrad.nnet.activations import sigmoid
+from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
+
+
+@fwdprop_test_factory(
+    mygrad_func=sigmoid, true_func=lambda x: 1 / (1 + np.exp(-x)), num_arrays=1
+)
+def test_sigmoid_fwd():
+    pass
+
+
+def _not_large(*arrs, **kwargs):
+    x = arrs[0]
+    return np.all(np.abs(x.data) < 500)
+
+
+@backprop_test_factory(
+    mygrad_func=sigmoid, true_func=lambda x: 1 / (1 + np.exp(-x)), num_arrays=1, assumptions=_not_large
+)
+def test_sigmoid_bkwd():
+    pass


### PR DESCRIPTION
Closes #182

Also fixes this error I found:


``` python
Python 3.6.4 |Anaconda, Inc.| (default, Mar 13 2018, 01:15:57) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.7.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from mygrad.nnet import sigmoid                                                                                        

In [2]: sigmoid(0)                                                                                                             
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-543cf44917cb> in <module>
----> 1 sigmoid(0)

/opt/conda/envs/lab42/lib/python3.6/site-packages/mygrad/nnet/activations/sigmoid.py in sigmoid(x, constant)
     45     Tensor([0.00669285, 0.02005754, 0.0585369 , 0.1588691 , 0.36457644,
     46         0.63542356, 0.8411309 , 0.9414631 , 0.97994246, 0.99330715])"""
---> 47     return Tensor._op(Sigmoid, x, constant=constant)

/opt/conda/envs/lab42/lib/python3.6/site-packages/mygrad/tensor_base.py in _op(cls, Op, op_args, op_kwargs, constant, *input_vars)
    223             )
    224         )
--> 225         op_out = f(*tensor_vars, *op_args, **op_kwargs)
    226 
    227         if isinstance(f, BroadcastableOp) and not f.scalar_only:

/opt/conda/envs/lab42/lib/python3.6/site-packages/mygrad/nnet/activations/sigmoid.py in __call__(self, a)
      9         self.variables = (a,)
     10         x = -1.0 * a.data
---> 11         np.exp(x, out=x)
     12         x += 1
     13         np.reciprocal(x, out=x)

TypeError: return arrays must be of ArrayType
```

Any idea why `x = -1.0 * a.data` would sometimes return a scalar instead of a NumPy array?