### PR TITLE
Settable shape

### DIFF
--- a/src/mygrad/__init__.py
+++ b/src/mygrad/__init__.py
@@ -38,7 +38,6 @@ for attr in (
     swapaxes,
     transpose,
     moveaxis,
-    reshape,
     squeeze,
     ravel,
     matmul,

--- a/src/mygrad/indexing_routines/funcs.py
+++ b/src/mygrad/indexing_routines/funcs.py
@@ -96,5 +96,5 @@ def where(condition, x=not_set, y=not_set, constant=False):
         raise ValueError("either both or neither of x and y should be given")
 
     return Tensor._op(
-        Where, x, y, op_kwargs=dict(condition=condition), constant=constant
+        Where, x, y, op_kwargs=dict(condition=condition), force_constant=constant
     )

--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -106,7 +106,7 @@ def matmul(a, b, constant=False):
     Traceback (most recent call last):
     ...
     ValueError: Scalar operands are not allowed, use '*' instead"""
-    return Tensor._op(MatMul, a, b, constant=constant)
+    return Tensor._op(MatMul, a, b, force_constant=constant)
 
 
 def einsum(*operands, optimize=False, constant=False):
@@ -365,7 +365,7 @@ def einsum(*operands, optimize=False, constant=False):
         EinSum,
         *variables,
         op_kwargs=dict(in_lbls=in_lbls, out_lbls=out_lbls, optimize=optimize),
-        constant=constant
+        force_constant=constant
     )
 
 

--- a/src/mygrad/math/arithmetic/funcs.py
+++ b/src/mygrad/math/arithmetic/funcs.py
@@ -57,7 +57,7 @@ def add(a, b, constant=False):
     Tensor([[  0.,   2.,   4.],
             [  3.,   5.,   7.],
             [  6.,   8.,  10.]])"""
-    return Tensor._op(Add, a, b, constant=constant)
+    return Tensor._op(Add, a, b, force_constant=constant)
 
 
 def subtract(a, b, constant=False):
@@ -89,7 +89,7 @@ def subtract(a, b, constant=False):
             [  3.,   3.,   3.],
             [  6.,   6.,  6.]])
     """
-    return Tensor._op(Subtract, a, b, constant=constant)
+    return Tensor._op(Subtract, a, b, force_constant=constant)
 
 
 def divide(a, b, constant=False):
@@ -108,7 +108,7 @@ def divide(a, b, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Divide, a, b, constant=constant)
+    return Tensor._op(Divide, a, b, force_constant=constant)
 
 
 def square(a, constant=False):
@@ -125,7 +125,7 @@ def square(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Square, a, constant=constant)
+    return Tensor._op(Square, a, force_constant=constant)
 
 
 def reciprocal(a, constant=False):
@@ -142,7 +142,7 @@ def reciprocal(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Reciprocal, a, constant=constant)
+    return Tensor._op(Reciprocal, a, force_constant=constant)
 
 
 def power(a, b, constant=False):
@@ -161,7 +161,7 @@ def power(a, b, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Power, a, b, constant=constant)
+    return Tensor._op(Power, a, b, force_constant=constant)
 
 
 def multiply(a, b, constant=False):
@@ -180,7 +180,7 @@ def multiply(a, b, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Multiply, a, b, constant=constant)
+    return Tensor._op(Multiply, a, b, force_constant=constant)
 
 
 def multiply_sequence(*variables, constant=False):
@@ -211,7 +211,7 @@ def multiply_sequence(*variables, constant=False):
                 len(variables)
             )
         )
-    return Tensor._op(MultiplySequence, *variables, constant=constant)
+    return Tensor._op(MultiplySequence, *variables, force_constant=constant)
 
 
 def add_sequence(*variables, constant=False):
@@ -242,7 +242,7 @@ def add_sequence(*variables, constant=False):
                 len(variables)
             )
         )
-    return Tensor._op(AddSequence, *variables, constant=constant)
+    return Tensor._op(AddSequence, *variables, force_constant=constant)
 
 
 def positive(a, where=True, constant=False):
@@ -267,7 +267,9 @@ def positive(a, where=True, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Positive, a, op_kwargs=(dict(where=where)), constant=constant)
+    return Tensor._op(
+        Positive, a, op_kwargs=(dict(where=where)), force_constant=constant
+    )
 
 
 def negative(a, where=True, constant=False):
@@ -292,4 +294,6 @@ def negative(a, where=True, constant=False):
     mygrad.Tensor
 
 """
-    return Tensor._op(Negative, a, op_kwargs=(dict(where=where)), constant=constant)
+    return Tensor._op(
+        Negative, a, op_kwargs=(dict(where=where)), force_constant=constant
+    )

--- a/src/mygrad/math/exp_log/funcs.py
+++ b/src/mygrad/math/exp_log/funcs.py
@@ -29,7 +29,7 @@ def exp(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Exp, a, constant=constant)
+    return Tensor._op(Exp, a, force_constant=constant)
 
 
 def exp2(a, constant=False):
@@ -46,7 +46,7 @@ def exp2(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Exp2, a, constant=constant)
+    return Tensor._op(Exp2, a, force_constant=constant)
 
 
 def expm1(a, constant=False):
@@ -70,7 +70,7 @@ def expm1(a, constant=False):
     -----
     This function provides greater precision than ``exp(x) - 1`` for
     small values of ``x``."""
-    return Tensor._op(Expm1, a, constant=constant)
+    return Tensor._op(Expm1, a, force_constant=constant)
 
 
 def logaddexp(a, b, constant=False):
@@ -98,7 +98,7 @@ def logaddexp(a, b, constant=False):
     numbers. In such cases the logarithm of the calculated
     probability is stored. This function allows adding probabilities
     stored in such a fashion. """
-    return Tensor._op(Logaddexp, a, b, constant=constant)
+    return Tensor._op(Logaddexp, a, b, force_constant=constant)
 
 
 def logaddexp2(a, b, constant=False):
@@ -128,7 +128,7 @@ def logaddexp2(a, b, constant=False):
     numbers. In such cases the logarithm of the calculated
     probability is stored. This function allows adding probabilities
     stored in such a fashion. """
-    return Tensor._op(Logaddexp2, a, b, constant=constant)
+    return Tensor._op(Logaddexp2, a, b, force_constant=constant)
 
 
 def log(a, constant=False):
@@ -152,7 +152,7 @@ def log(a, constant=False):
     -----
     This function provides greater precision than ``exp(x) - 1`` for
     small values of ``x``."""
-    return Tensor._op(Log, a, constant=constant)
+    return Tensor._op(Log, a, force_constant=constant)
 
 
 def log2(a, constant=False):
@@ -171,7 +171,7 @@ def log2(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Log2, a, constant=constant)
+    return Tensor._op(Log2, a, force_constant=constant)
 
 
 def log10(a, constant=False):
@@ -190,7 +190,7 @@ def log10(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Log10, a, constant=constant)
+    return Tensor._op(Log10, a, force_constant=constant)
 
 
 def log1p(a, constant=False):
@@ -215,4 +215,4 @@ def log1p(a, constant=False):
     For real-valued input, log1p is accurate also
     for ``x`` so small that ``1 + x == 1`` in floating-point
     accuracy."""
-    return Tensor._op(Log1p, a, constant=constant)
+    return Tensor._op(Log1p, a, force_constant=constant)

--- a/src/mygrad/math/hyperbolic_trig/funcs.py
+++ b/src/mygrad/math/hyperbolic_trig/funcs.py
@@ -31,7 +31,7 @@ def arccosh(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arccosh, a, constant=constant)
+    return Tensor._op(Arccosh, a, force_constant=constant)
 
 
 def arccoth(a, constant=False):
@@ -48,7 +48,7 @@ def arccoth(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arccoth, a, constant=constant)
+    return Tensor._op(Arccoth, a, force_constant=constant)
 
 
 def arccsch(a, constant=False):
@@ -65,7 +65,7 @@ def arccsch(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arccsch, a, constant=constant)
+    return Tensor._op(Arccsch, a, force_constant=constant)
 
 
 def arcsinh(a, constant=False):
@@ -82,7 +82,7 @@ def arcsinh(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arcsinh, a, constant=constant)
+    return Tensor._op(Arcsinh, a, force_constant=constant)
 
 
 def arctanh(a, constant=False):
@@ -99,7 +99,7 @@ def arctanh(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arctanh, a, constant=constant)
+    return Tensor._op(Arctanh, a, force_constant=constant)
 
 
 def cosh(a, constant=False):
@@ -116,7 +116,7 @@ def cosh(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Cosh, a, constant=constant)
+    return Tensor._op(Cosh, a, force_constant=constant)
 
 
 def coth(a, constant=False):
@@ -133,7 +133,7 @@ def coth(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Coth, a, constant=constant)
+    return Tensor._op(Coth, a, force_constant=constant)
 
 
 def csch(a, constant=False):
@@ -150,7 +150,7 @@ def csch(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Csch, a, constant=constant)
+    return Tensor._op(Csch, a, force_constant=constant)
 
 
 def sech(a, constant=False):
@@ -167,7 +167,7 @@ def sech(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Sech, a, constant=constant)
+    return Tensor._op(Sech, a, force_constant=constant)
 
 
 def sinh(a, constant=False):
@@ -184,7 +184,7 @@ def sinh(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Sinh, a, constant=constant)
+    return Tensor._op(Sinh, a, force_constant=constant)
 
 
 def tanh(x, constant=False):
@@ -212,4 +212,4 @@ def tanh(x, constant=False):
     Tensor([-0.9999092 , -0.99916247, -0.99229794, -0.93110961, -0.5046724 ,
              0.5046724 ,  0.93110961,  0.99229794,  0.99916247,  0.9999092 ])
     """
-    return Tensor._op(Tanh, x, constant=constant)
+    return Tensor._op(Tanh, x, force_constant=constant)

--- a/src/mygrad/math/misc/funcs.py
+++ b/src/mygrad/math/misc/funcs.py
@@ -23,7 +23,7 @@ def abs(a, constant=False):
     Notes
     -----
     The derivative at a == 0 returns nan"""
-    return Tensor._op(Abs, a, constant=constant)
+    return Tensor._op(Abs, a, force_constant=constant)
 
 
 absolute = abs
@@ -43,7 +43,7 @@ def sqrt(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Sqrt, a, constant=constant)
+    return Tensor._op(Sqrt, a, force_constant=constant)
 
 
 def cbrt(a, constant=False):
@@ -60,7 +60,7 @@ def cbrt(a, constant=False):
     Returns
     -------
     mygrad.Tensor"""
-    return Tensor._op(Cbrt, a, constant=constant)
+    return Tensor._op(Cbrt, a, force_constant=constant)
 
 
 def maximum(a, b, constant=False):
@@ -84,7 +84,7 @@ def maximum(a, b, constant=False):
     -----
     The gradient does not exist where a == b; we use a
     value of 0 here."""
-    return Tensor._op(Maximum, a, b, constant=constant)
+    return Tensor._op(Maximum, a, b, force_constant=constant)
 
 
 def minimum(a, b, constant=False):
@@ -108,7 +108,7 @@ def minimum(a, b, constant=False):
     -----
     The gradient does not exist where a == b; we use a
     value of 0 here."""
-    return Tensor._op(Minimum, a, b, constant=constant)
+    return Tensor._op(Minimum, a, b, force_constant=constant)
 
 
 def clip(a, a_min, a_max, constant=False):

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -92,7 +92,7 @@ def sum(x, axis=None, keepdims=False, constant=False):
     >>> mg.sum([10], initial=5)
     Tensor(15)
     """
-    return Tensor._op(Sum, x, op_args=(axis, keepdims), constant=constant)
+    return Tensor._op(Sum, x, op_args=(axis, keepdims), force_constant=constant)
 
 
 def mean(x, axis=None, keepdims=False, constant=False):
@@ -154,7 +154,7 @@ def mean(x, axis=None, keepdims=False, constant=False):
     >>> mg.mean(a, dtype=np.float64)
     Tensor(0.55000000074505806)
     """
-    return Tensor._op(Mean, x, op_args=(axis, keepdims), constant=constant)
+    return Tensor._op(Mean, x, op_args=(axis, keepdims), force_constant=constant)
 
 
 def var(x, axis=None, ddof=0, keepdims=False, constant=False):
@@ -236,7 +236,7 @@ def var(x, axis=None, ddof=0, keepdims=False, constant=False):
         Variance,
         x,
         op_kwargs=dict(axis=axis, keepdims=keepdims, ddof=ddof),
-        constant=constant,
+        force_constant=constant,
     )
 
 
@@ -317,7 +317,7 @@ def std(x, axis=None, ddof=0, keepdims=False, constant=False):
         StdDev,
         x,
         op_kwargs=dict(axis=axis, keepdims=keepdims, ddof=ddof),
-        constant=constant,
+        force_constant=constant,
     )
 
 
@@ -369,7 +369,7 @@ def max(x, axis=None, keepdims=False, constant=False):
         MaxMin,
         x,
         op_kwargs=dict(axis=axis, keepdims=keepdims, maxmin="max"),
-        constant=constant,
+        force_constant=constant,
     )
 
 
@@ -419,7 +419,7 @@ def min(x, axis=None, keepdims=False, constant=False):
         MaxMin,
         x,
         op_kwargs=dict(axis=axis, keepdims=keepdims, maxmin="min"),
-        constant=constant,
+        force_constant=constant,
     )
 
 
@@ -478,7 +478,7 @@ def prod(a, axis=None, keepdims=False, constant=False):
     ...          [3.,4.]], axis=1)
     Tensor([  2.,  12.]) """
     return Tensor._op(
-        Prod, a, op_kwargs=dict(axis=axis, keepdims=keepdims), constant=constant
+        Prod, a, op_kwargs=dict(axis=axis, keepdims=keepdims), force_constant=constant
     )
 
 
@@ -531,7 +531,7 @@ def cumprod(a, axis=None, constant=False):
     Tensor([[  1,   2,   6],
             [  4,  20, 120]])"""
 
-    return Tensor._op(CumProd, a, op_kwargs=dict(axis=axis), constant=constant)
+    return Tensor._op(CumProd, a, op_kwargs=dict(axis=axis), force_constant=constant)
 
 
 def cumsum(a, axis=None, constant=False):
@@ -573,4 +573,4 @@ def cumsum(a, axis=None, constant=False):
             [ 4,  9, 15]])
     """
 
-    return Tensor._op(CumSum, a, op_kwargs=dict(axis=axis), constant=constant)
+    return Tensor._op(CumSum, a, op_kwargs=dict(axis=axis), force_constant=constant)

--- a/src/mygrad/math/trigonometric/funcs.py
+++ b/src/mygrad/math/trigonometric/funcs.py
@@ -34,7 +34,7 @@ def sin(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Sin, a, constant=constant)
+    return Tensor._op(Sin, a, force_constant=constant)
 
 
 def sinc(a, constant=False):
@@ -51,7 +51,7 @@ def sinc(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Sinc, a, constant=constant)
+    return Tensor._op(Sinc, a, force_constant=constant)
 
 
 def cos(a, constant=False):
@@ -68,7 +68,7 @@ def cos(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Cos, a, constant=constant)
+    return Tensor._op(Cos, a, force_constant=constant)
 
 
 def tan(a, constant=False):
@@ -85,7 +85,7 @@ def tan(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Tan, a, constant=constant)
+    return Tensor._op(Tan, a, force_constant=constant)
 
 
 def cot(a, constant=False):
@@ -102,7 +102,7 @@ def cot(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Cot, a, constant=constant)
+    return Tensor._op(Cot, a, force_constant=constant)
 
 
 def csc(a, constant=False):
@@ -119,7 +119,7 @@ def csc(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Csc, a, constant=constant)
+    return Tensor._op(Csc, a, force_constant=constant)
 
 
 def sec(a, constant=False):
@@ -136,7 +136,7 @@ def sec(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Sec, a, constant=constant)
+    return Tensor._op(Sec, a, force_constant=constant)
 
 
 def arccos(a, constant=False):
@@ -153,7 +153,7 @@ def arccos(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arccos, a, constant=constant)
+    return Tensor._op(Arccos, a, force_constant=constant)
 
 
 def arccsc(a, constant=False):
@@ -170,7 +170,7 @@ def arccsc(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arccsc, a, constant=constant)
+    return Tensor._op(Arccsc, a, force_constant=constant)
 
 
 def arccot(a, constant=False):
@@ -187,7 +187,7 @@ def arccot(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arccot, a, constant=constant)
+    return Tensor._op(Arccot, a, force_constant=constant)
 
 
 def arcsin(a, constant=False):
@@ -204,7 +204,7 @@ def arcsin(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arcsin, a, constant=constant)
+    return Tensor._op(Arcsin, a, force_constant=constant)
 
 
 def arctan(a, constant=False):
@@ -221,7 +221,7 @@ def arctan(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arctan, a, constant=constant)
+    return Tensor._op(Arctan, a, force_constant=constant)
 
 
 def arcsec(a, constant=False):
@@ -238,7 +238,7 @@ def arcsec(a, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arcsec, a, constant=constant)
+    return Tensor._op(Arcsec, a, force_constant=constant)
 
 
 def arctan2(a, b, constant=False):
@@ -256,4 +256,4 @@ def arctan2(a, b, constant=False):
         Returns
         -------
         mygrad.Tensor"""
-    return Tensor._op(Arctan2, a, b, constant=constant)
+    return Tensor._op(Arctan2, a, b, force_constant=constant)

--- a/src/mygrad/nnet/activations/relu.py
+++ b/src/mygrad/nnet/activations/relu.py
@@ -47,4 +47,4 @@ def relu(x, constant=False):
     >>> x.grad  # d(relu(x))/dx
     array([0., 0., 0., 1., 1.])
     """
-    return Tensor._op(ReLu, x, constant=constant)
+    return Tensor._op(ReLu, x, force_constant=constant)

--- a/src/mygrad/nnet/activations/sigmoid.py
+++ b/src/mygrad/nnet/activations/sigmoid.py
@@ -44,4 +44,4 @@ def sigmoid(x, constant=False):
     >>> sigmoid(x)
     Tensor([0.00669285, 0.02005754, 0.0585369 , 0.1588691 , 0.36457644,
         0.63542356, 0.8411309 , 0.9414631 , 0.97994246, 0.99330715])"""
-    return Tensor._op(Sigmoid, x, constant=constant)
+    return Tensor._op(Sigmoid, x, force_constant=constant)

--- a/src/mygrad/nnet/activations/softmax.py
+++ b/src/mygrad/nnet/activations/softmax.py
@@ -62,7 +62,7 @@ def softmax(x, constant=False):
     -----
     - :math:`N` is the number of samples in the batch.
     - :math:`C` is the number of possible classes for which scores are provided.
-    
+
     This implements a numerically-stable version of softmax, however
     log-softmax is still the more numerically stable activation function.
 
@@ -83,7 +83,7 @@ def softmax(x, constant=False):
     Tensor([[0.33333333, 0.33333333, 0.33333333],
             [0.5       , 0.5       , 0.        ]])
     """
-    return Tensor._op(Softmax, x, constant=constant)
+    return Tensor._op(Softmax, x, force_constant=constant)
 
 
 class LogSoftmax(Operation):
@@ -158,4 +158,4 @@ def logsoftmax(x, constant=False):
     Tensor([[-1.09861229e+00, -1.09861229e+00, -1.09861229e+00],
             [ 0.00000000e+00,  0.00000000e+00, -1.00000000e+50]])
     """
-    return Tensor._op(LogSoftmax, x, constant=constant)
+    return Tensor._op(LogSoftmax, x, force_constant=constant)

--- a/src/mygrad/nnet/layers/batchnorm.py
+++ b/src/mygrad/nnet/layers/batchnorm.py
@@ -161,5 +161,5 @@ def batchnorm(x, *, gamma=None, beta=None, eps, constant=False):
     if beta is None:
         beta = np.array([])
     return Tensor._op(
-        BatchNorm, x, gamma, beta, op_kwargs=dict(eps=eps), constant=constant
+        BatchNorm, x, gamma, beta, op_kwargs=dict(eps=eps), force_constant=constant
     )

--- a/src/mygrad/nnet/layers/conv.py
+++ b/src/mygrad/nnet/layers/conv.py
@@ -305,5 +305,5 @@ def conv_nd(x, filter_bank, *, stride, padding=0, dilation=1, constant=False):
         x,
         filter_bank,
         op_kwargs=dict(stride=stride, padding=padding, dilation=dilation),
-        constant=constant,
+        force_constant=constant,
     )

--- a/src/mygrad/nnet/layers/gru.py
+++ b/src/mygrad/nnet/layers/gru.py
@@ -204,7 +204,7 @@ class GRUnit(Operation):
             self.bh,
         )
         T, N, C = X.shape
-        D, = bz.shape
+        (D,) = bz.shape
 
         seq = self.X.data
 
@@ -546,7 +546,7 @@ def gru(
         Wh,
         bh,
         op_kwargs=dict(s0=s0, bp_lim=bp_lim, dropout=dropout),
-        constant=constant,
+        force_constant=constant,
     )
     s.creator._hidden_seq = s
     return s

--- a/src/mygrad/nnet/layers/pooling.py
+++ b/src/mygrad/nnet/layers/pooling.py
@@ -235,4 +235,4 @@ def max_pool(x, pool, stride, constant=False):
     pooling window would have been tiled along the last *three* axes
     of ``x``.
     """
-    return Tensor._op(MaxPoolND, x, op_args=(pool, stride), constant=constant)
+    return Tensor._op(MaxPoolND, x, op_args=(pool, stride), force_constant=constant)

--- a/src/mygrad/nnet/losses/margin_ranking_loss.py
+++ b/src/mygrad/nnet/losses/margin_ranking_loss.py
@@ -102,4 +102,6 @@ def margin_ranking_loss(x1, x2, y, margin, constant=False):
     if y.ndim:
         if x1.ndim == 2:
             y = y.reshape(-1, 1)
-    return Tensor._op(MarginRanking, x1, x2, op_args=(y, margin), constant=constant)
+    return Tensor._op(
+        MarginRanking, x1, x2, op_args=(y, margin), force_constant=constant
+    )

--- a/src/mygrad/nnet/losses/multiclass_hinge.py
+++ b/src/mygrad/nnet/losses/multiclass_hinge.py
@@ -87,4 +87,6 @@ def multiclass_hinge(x, y_true, hinge=1.0, constant=False):
         `x` must be a 2-dimensional array-like object
         `y_true` must be a shape-(N,) array-like object
     """
-    return Tensor._op(MulticlassHinge, x, op_args=(y_true, hinge), constant=constant)
+    return Tensor._op(
+        MulticlassHinge, x, op_args=(y_true, hinge), force_constant=constant
+    )

--- a/src/mygrad/nnet/losses/softmax_crossentropy.py
+++ b/src/mygrad/nnet/losses/softmax_crossentropy.py
@@ -149,4 +149,6 @@ def softmax_crossentropy(x, y_true, constant=False):
     >>> softmax_crossentropy(x, y_true)
     Tensor(0.54930614)
     """
-    return Tensor._op(SoftmaxCrossEntropy, x, op_args=(y_true,), constant=constant)
+    return Tensor._op(
+        SoftmaxCrossEntropy, x, op_args=(y_true,), force_constant=constant
+    )

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -829,7 +829,7 @@ class Tensor:
         Returns
         -------
         mygrad.Tensor
-            ``a`` with its shape changed permuted.  A new tensor is returned.
+            ``a`` with its shape changed.  A new tensor is returned.
 
         Notes
         -----

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -847,7 +847,8 @@ class Tensor:
         >>> a.reshape(3, -1))   # the unspecified value is inferred to be 2
         Tensor([[1, 2],
                 [3, 4],
-                [5, 6]])"""
+                [5, 6]])
+                """
 
         if not newshape:
             raise TypeError("reshape() takes at least 1 argument (0 given)")

--- a/src/mygrad/tensor_manip/array_shape/funcs.py
+++ b/src/mygrad/tensor_manip/array_shape/funcs.py
@@ -1,58 +1,52 @@
 from mygrad.tensor_base import Tensor
 
-from .ops import *
+from .ops import BroadcastTo, ExpandDims, Ravel, Reshape, Squeeze
 
 __all__ = ["reshape", "squeeze", "ravel", "expand_dims", "broadcast_to"]
 
 
-def reshape(a, *newshape, constant=False):
+def reshape(a, newshape, constant=False):
     """ Returns a tensor with a new shape, without changing its data.
 
-        This docstring was adapted from ``numpy.reshape``
+    This docstring was adapted from ``numpy.reshape``
 
-        Parameters
-        ----------
-        a : array_like
-            The tensor to be reshaped
+    Parameters
+    ----------
+    a : array_like
+        The tensor to be reshaped
 
-        *newshape : Union[int, Tuple[int, ...]]
-            The new shape should be compatible with the original shape. If
-            an integer, then the result will be a 1-D tensor of that length.
-            One shape dimension can be -1. In this case, the value is
-            inferred from the length of the tensor and remaining dimensions.
+    newshape : Union[int, Tuple[int, ...]]
+        The new shape should be compatible with the original shape. If
+        an integer, then the result will be a 1-D tensor of that length.
+        One shape dimension can be -1. In this case, the value is
+        inferred from the length of the tensor and remaining dimensions.
 
-        constant : bool, optional(default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : bool, optional(default=False)
+        If ``True``, the returned tensor is a constant (it
+        does not back-propagate a gradient)
 
-        Returns
-        -------
-        mygrad.Tensor
-            ``a`` with its shape changed permuted.  A new tensor is returned.
+    Returns
+    -------
+    mygrad.Tensor
+        ``a`` with its shape changed permuted.  A new tensor is returned.
 
-        Notes
-        -----
-        ``reshape`` utilizes C-ordering, meaning that it reads & writes elements using
-        C-like index ordering; the last axis index changing fastest, and, proceeding
-        in reverse order, the first axis index changing slowest. 
-            
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> a = mg.Tensor([[1,2,3], [4,5,6]])
-        >>> mg.reshape(a, 6)
-        Tensor([1, 2, 3, 4, 5, 6])
+    Notes
+    -----
+    ``reshape`` utilizes C-ordering, meaning that it reads & writes elements using
+    C-like index ordering; the last axis index changing fastest, and, proceeding
+    in reverse order, the first axis index changing slowest.
 
-        >>> mg.reshape(a, (3,-1))   # the unspecified value is inferred to be 2
-        Tensor([[1, 2],
-                [3, 4],
-                [5, 6]])"""
-    if not newshape:
-        raise TypeError("reshape() takes at least 1 argument (0 given)")
-    if hasattr(newshape[0], "__iter__"):
-        if len(newshape) > 1:
-            raise TypeError("an integer is required")
-        newshape = newshape[0]
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> a = mg.Tensor([[1,2,3], [4,5,6]])
+    >>> mg.reshape(a, 6)
+    Tensor([1, 2, 3, 4, 5, 6])
+
+    >>> mg.reshape(a, (3,-1))   # the unspecified value is inferred to be 2
+    Tensor([[1, 2],
+            [3, 4],
+            [5, 6]])"""
     return Tensor._op(Reshape, a, op_args=(newshape,), constant=constant)
 
 
@@ -66,10 +60,10 @@ def squeeze(a, axis=None, constant=False):
     ----------
     a : array_like
         The tensor to be reshaped
-    
+
     axis : Optional[int, Tuple[int, ...]]
-        Selects a subset of the single-dimensional entries in the 
-        shape. If an axis is selected with shape entry greater than 
+        Selects a subset of the single-dimensional entries in the
+        shape. If an axis is selected with shape entry greater than
         one, an error is raised.
 
     constant : bool, optional(default=False)

--- a/src/mygrad/tensor_manip/array_shape/funcs.py
+++ b/src/mygrad/tensor_manip/array_shape/funcs.py
@@ -47,7 +47,7 @@ def reshape(a, newshape, constant=False):
     Tensor([[1, 2],
             [3, 4],
             [5, 6]])"""
-    return Tensor._op(Reshape, a, op_args=(newshape,), constant=constant)
+    return Tensor._op(Reshape, a, op_args=(newshape,), force_constant=constant)
 
 
 def squeeze(a, axis=None, constant=False):
@@ -95,7 +95,7 @@ def squeeze(a, axis=None, constant=False):
     ValueError: cannot select an axis to squeeze out which has size not equal to one
     >>> mg.squeeze(x, axis=2).shape
     (1, 3)"""
-    return Tensor._op(Squeeze, a, op_args=(axis,), constant=constant)
+    return Tensor._op(Squeeze, a, op_args=(axis,), force_constant=constant)
 
 
 def ravel(a, constant=False):
@@ -131,7 +131,7 @@ def ravel(a, constant=False):
     >>> mg.ravel(x)
     Tensor([1, 2, 3, 4])
     """
-    return Tensor._op(Ravel, a, constant=constant)
+    return Tensor._op(Ravel, a, force_constant=constant)
 
 
 def expand_dims(a, axis, constant=False):
@@ -169,7 +169,7 @@ def expand_dims(a, axis, constant=False):
     >>> z.shape
     (1, 2, 1)
     """
-    return Tensor._op(ExpandDims, a, op_args=(axis,), constant=constant)
+    return Tensor._op(ExpandDims, a, op_args=(axis,), force_constant=constant)
 
 
 def broadcast_to(a, shape, constant=False):
@@ -216,4 +216,4 @@ def broadcast_to(a, shape, constant=False):
     ValueError: operands could not be broadcast together with remapped
     shapes [original->remapped]: (3,) and requested shape (4,4)
     """
-    return Tensor._op(BroadcastTo, a, op_args=(shape,), constant=constant)
+    return Tensor._op(BroadcastTo, a, op_args=(shape,), force_constant=constant)

--- a/src/mygrad/tensor_manip/array_shape/ops.py
+++ b/src/mygrad/tensor_manip/array_shape/ops.py
@@ -6,17 +6,17 @@ __all__ = ["Reshape", "Flatten", "Squeeze", "Ravel", "ExpandDims", "BroadcastTo"
 
 
 class Reshape(Operation):
-    def __call__(self, a, shape):
+    def __call__(self, a, newshape):
         """ Parameters
             ----------
             a : mygrad.Tensor
-            shape : Tuple[int, ...]"""
+            newshape : Tuple[int, ...]"""
         self.variables = (a,)
-        return a.data.reshape(shape)
+        return np.reshape(a.data, newshape)
 
     def backward_var(self, grad, index, **kwargs):
         a = self.variables[index]
-        return grad.reshape(*a.shape)
+        return np.reshape(grad, a.shape)
 
 
 class Squeeze(Operation):

--- a/src/mygrad/tensor_manip/tiling/funcs.py
+++ b/src/mygrad/tensor_manip/tiling/funcs.py
@@ -57,4 +57,4 @@ def repeat(
             [3, 4],
             [3, 4]])
     """
-    return Tensor._op(Repeat, a, op_args=(repeats, axis), constant=constant)
+    return Tensor._op(Repeat, a, op_args=(repeats, axis), force_constant=constant)

--- a/src/mygrad/tensor_manip/transpose_like/funcs.py
+++ b/src/mygrad/tensor_manip/transpose_like/funcs.py
@@ -46,7 +46,7 @@ def transpose(a, *axes, constant=False):
                 "'{}' object cannot be interpreted as an integer".format(type(axes[0]))
             )
         axes = axes[0]
-    return Tensor._op(Transpose, a, op_args=(axes,), constant=constant)
+    return Tensor._op(Transpose, a, op_args=(axes,), force_constant=constant)
 
 
 def moveaxis(a, source, destination, constant=False):
@@ -85,7 +85,9 @@ def moveaxis(a, source, destination, constant=False):
         (5, 3, 4)
         >>> moveaxis(x, [0, 1], [-1, -2]).shape
         (5, 4, 3) """
-    return Tensor._op(MoveAxis, a, op_args=(source, destination), constant=constant)
+    return Tensor._op(
+        MoveAxis, a, op_args=(source, destination), force_constant=constant
+    )
 
 
 def swapaxes(a, axis1, axis2, constant=False):
@@ -130,7 +132,7 @@ def swapaxes(a, axis1, axis2, constant=False):
                [[1, 5],
                 [3, 7]]])
     """
-    return Tensor._op(SwapAxes, a, op_args=(axis1, axis2), constant=constant)
+    return Tensor._op(SwapAxes, a, op_args=(axis1, axis2), force_constant=constant)
 
 
 def roll(a, shift, axis=None, constant=False):
@@ -185,5 +187,5 @@ def roll(a, shift, axis=None, constant=False):
            [9, 5, 6, 7, 8]])
     """
     return Tensor._op(
-        Roll, a, op_kwargs=dict(shift=shift, axis=axis), constant=constant
+        Roll, a, op_kwargs=dict(shift=shift, axis=axis), force_constant=constant
     )

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -1,11 +1,12 @@
 """ Custom hypothesis search strategies """
 import math
-from functools import partial
+from functools import lru_cache, partial
 from numbers import Integral
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Tuple, Union
 
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
+import numpy as np
 from hypothesis.extra.numpy import broadcastable_shapes
 from numpy import ndarray
 
@@ -184,7 +185,7 @@ def valid_axes(
     return strat
 
 
-def integer_index(size):
+def integer_index(size: int) -> st.SearchStrategy[int]:
     """ Generate a valid integer-index for an axis of a given size,
     either a positive or negative value: [-size, size).
 
@@ -312,4 +313,54 @@ def adv_integer_index(
         result_shape=hnp.array_shapes(
             min_dims=min_dims, max_dims=max_dims, min_side=min_side, max_side=max_side
         ),
+    )
+
+
+@lru_cache(maxsize=1000)
+def _factors(n: int) -> List[int]:
+    """ Returns the divisors of n
+
+        >>> _factors(4)
+        {1, 2, 4}"""
+    if not isinstance(n, int) and 0 <= n:
+        raise ValueError("n={} must be a non-negative integer".format(n))
+    gen = ([i, n // i] for i in range(1, int(n ** 0.5) + 1) if n % i == 0)
+    return sorted(set(sum(gen, [])))
+
+
+@st.composite
+def valid_shapes(
+    draw, size: int, min_len: int = 1, max_len: int = 6
+) -> st.SearchStrategy[Union[int, Tuple[int, ...]]]:
+    """ Given an array's size, generate a compatible random shape
+
+    Parameters
+    ----------
+    size : int
+    min_len : int
+    max_len : int
+
+    Returns
+    -------
+    st.SearchStrategy[Tuple[int, ...]]
+    """
+
+    if not isinstance(size, int) or size < 0:
+        raise ValueError("size={} must be a non-negative integer".format(size))
+
+    shape_length = draw(st.integers(min_len, max_len))  # type: int
+    shape = []  # type: List[int]
+    rem = int(size / np.prod(shape))
+    while len(shape) < shape_length:
+        if len(shape) == shape_length - 1:
+            shape.append(-1 if draw(st.booleans()) else rem)
+            break
+
+        shape.append(draw(st.sampled_from(_factors(rem))))
+        rem = int(size / np.prod(shape))
+
+    return (
+        shape[0]
+        if len(shape) == 1 and draw(st.booleans())
+        else tuple(int(i) for i in shape)
     )

--- a/tests/custom_strategies/test_strategies.py
+++ b/tests/custom_strategies/test_strategies.py
@@ -5,14 +5,17 @@ import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
 from hypothesis import given, note
+from numpy.testing import assert_array_equal
 
 from tests.custom_strategies import (
+    _factors,
     adv_integer_index,
     basic_indices,
     choices,
     integer_index,
     slice_index,
     valid_axes,
+    valid_shapes,
 )
 
 
@@ -156,3 +159,22 @@ def test_valid_axes(shape, data, permit_none, pos_only):
                 assert len(axis) <= max_dim
         else:
             assert min_dim <= 1
+
+
+@given(st.integers(min_value=0, max_value=1000))
+def test_factors(size: int):
+    factors = _factors(size)
+    a_factors = np.array(factors)
+    assert len(set(a_factors)) == len(a_factors)
+    assert_array_equal(a_factors * a_factors[::-1], size)
+
+
+@given(
+    arr=hnp.arrays(
+        dtype=bool, fill=st.just(False), shape=hnp.array_shapes(min_dims=0, max_dims=10)
+    ),
+    data=st.data(),
+)
+def test_valid_shapes(arr: np.ndarray, data: st.DataObject):
+    newshape = data.draw(valid_shapes(arr.size), label="newshape")
+    arr.reshape(newshape)

--- a/tests/tensor_base/test_op_wrapper.py
+++ b/tests/tensor_base/test_op_wrapper.py
@@ -9,7 +9,7 @@ class Dummy(Operation):
 
 
 def dummy(a, b, constant=False):
-    return Tensor._op(Dummy, a, b, constant=constant)
+    return Tensor._op(Dummy, a, b, force_constant=constant)
 
 
 def test_constant_arg():

--- a/tests/tensor_ops/test_reshape.py
+++ b/tests/tensor_ops/test_reshape.py
@@ -106,7 +106,7 @@ def test_reshape_bkwd(reshape_type):
     "bad_input", [tuple(), ((2,), 2), (((2,), 2)), (2, (2,)), ((2, (2,)))]
 )
 def test_input_validation(bad_input):
-    x = np.array([1, 2])
+    x = Tensor([1, 2])
 
     with pytest.raises(TypeError):
         x.reshape(*bad_input)

--- a/tests/tensor_ops/test_reshape.py
+++ b/tests/tensor_ops/test_reshape.py
@@ -1,128 +1,98 @@
-import hypothesis.extra.numpy as hnp
-import hypothesis.strategies as st
+from functools import partial
+from numbers import Number
+
 import numpy as np
 import pytest
-from hypothesis import given
-from numpy.testing import assert_allclose
 
 from mygrad import reshape
 from mygrad.tensor_base import Tensor
 
-
-def gen_shape(size):
-    """ Given an array's size, generate a compatible random shape
-
-        Parameters
-        ----------
-        size : Integral
-
-        Returns
-        -------
-        Tuple[int, ...] """
-
-    def _factors(n):
-        """ Returns the divisors of n
-
-            >>> _factors(4)
-            {1, 2, 4}"""
-        gen = ([i, n // i] for i in range(1, int(n ** 0.5) + 1) if n % i == 0)
-        return set(sum(gen, []))
-
-    assert size > 0
-    if size == 1:
-        return (1,)
-
-    shape = []
-    rem = int(size / np.prod(shape))
-    while rem > 1:
-        if len(shape) > 6:
-            shape.append(rem)
-            break
-
-        shape.append(np.random.choice(list(_factors(rem))))
-        rem = int(size / np.prod(shape))
-
-    return tuple(int(i) for i in shape)
+from ..custom_strategies import valid_shapes
+from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
-def test_input_validation():
+def positional_reshape(arr, newshape, reshaper, **kwargs):
+    return reshaper(arr, newshape, **kwargs)
+
+
+def keyword_reshape(arr, newshape, reshaper, **kwargs):
+    return reshaper(arr, newshape=newshape, **kwargs)
+
+
+def unpacked_reshape(arr, newshape, reshaper, **kwargs):
+    return reshaper(arr, *newshape, **kwargs)
+
+
+def method_tuple_reshape(arr, newshape, reshaper, **kwargs):
+    to_array = np.asarray if reshaper is np.reshape else Tensor
+    if isinstance(arr, Number):
+        arr = to_array(arr)
+    return arr.reshape(newshape, **kwargs)
+
+
+def method_unpacked_reshape(arr, newshape, reshaper, **kwargs):
+    to_array = np.asarray if reshaper is np.reshape else Tensor
+    if isinstance(arr, Number):
+        arr = to_array(arr)
+
+    return (
+        arr.reshape(*newshape, **kwargs)
+        if isinstance(newshape, tuple)
+        else arr.reshape(newshape, **kwargs)
+    )
+
+
+@pytest.mark.parametrize(
+    "reshape_type",
+    [
+        positional_reshape,
+        keyword_reshape,
+        method_tuple_reshape,
+        method_unpacked_reshape,
+    ],
+)
+def test_reshape_fwd(reshape_type):
+    @fwdprop_test_factory(
+        mygrad_func=partial(reshape_type, reshaper=reshape),
+        true_func=partial(reshape_type, reshaper=np.reshape),
+        num_arrays=1,
+        kwargs=dict(newshape=lambda arrs: valid_shapes(arrs.size)),
+    )
+    def test_fwd():
+        pass
+
+    test_fwd()
+
+
+@pytest.mark.parametrize(
+    "reshape_type",
+    [
+        positional_reshape,
+        keyword_reshape,
+        method_tuple_reshape,
+        method_unpacked_reshape,
+    ],
+)
+def test_reshape_bkwd(reshape_type):
+    @backprop_test_factory(
+        mygrad_func=partial(reshape_type, reshaper=reshape),
+        true_func=partial(reshape_type, reshaper=np.reshape),
+        num_arrays=1,
+        kwargs=dict(newshape=lambda arrs: valid_shapes(arrs.size)),
+        vary_each_element=True,
+        atol=1e-9,
+    )
+    def test_bkwd():
+        pass
+
+    test_bkwd()
+
+
+@pytest.mark.parametrize(
+    "bad_input", [tuple(), ((2,), 2), (((2,), 2)), (2, (2,)), ((2, (2,)))]
+)
+def test_input_validation(bad_input):
     x = np.array([1, 2])
 
     with pytest.raises(TypeError):
-        reshape(x)
-
-    with pytest.raises(TypeError):
-        reshape(x, (2,), 2)
-
-
-@given(
-    a=hnp.arrays(
-        shape=hnp.array_shapes(max_side=3, max_dims=5),
-        dtype=float,
-        elements=st.floats(-100, 100),
-    )
-)
-def test_reshape_method_fwd(a):
-    new_shape = gen_shape(a.size)
-
-    x = Tensor(a).reshape(new_shape)
-    a = a.reshape(new_shape)
-
-    assert x.shape == a.shape, "Tensor.reshape failed"
-    assert_allclose(a, x.data), "Tensor.reshape failed"
-
-
-@given(
-    a=hnp.arrays(
-        shape=hnp.array_shapes(max_side=3, max_dims=5),
-        dtype=float,
-        elements=st.floats(-100, 100),
-    )
-)
-def test_reshape_method_backward(a):
-    new_shape = gen_shape(a.size)
-    grad = np.arange(a.size).reshape(a.shape)
-
-    x = Tensor(a)
-    o = x.reshape(new_shape)
-    o.backward(grad.reshape(new_shape))
-
-    assert x.grad.shape == grad.shape
-    assert_allclose(x.grad, grad)
-
-
-@given(
-    a=hnp.arrays(
-        shape=hnp.array_shapes(max_side=3, max_dims=5),
-        dtype=float,
-        elements=st.floats(-100, 100),
-    )
-)
-def test_reshape_fwd(a):
-    new_shape = gen_shape(a.size)
-
-    x = Tensor(a)
-    x = reshape(x, new_shape, constant=True)
-    a = a.reshape(new_shape)
-
-    assert x.shape == a.shape, "Tensor.reshape failed"
-    assert_allclose(a, x.data), "Tensor.reshape failed"
-
-
-@given(
-    a=hnp.arrays(
-        shape=hnp.array_shapes(max_side=3, max_dims=5),
-        dtype=float,
-        elements=st.floats(-100, 100),
-    )
-)
-def test_reshape_backward(a):
-    new_shape = gen_shape(a.size)
-    grad = np.arange(a.size).reshape(a.shape)
-
-    x = Tensor(a)
-    o = reshape(x, new_shape, constant=False)
-    o.backward(grad.reshape(new_shape))
-
-    assert x.grad.shape == grad.shape
-    assert_allclose(x.grad, grad)
+        x.reshape(*bad_input)

--- a/tests/tensor_ops/test_reshape.py
+++ b/tests/tensor_ops/test_reshape.py
@@ -42,6 +42,19 @@ def method_unpacked_reshape(arr, newshape, reshaper, **kwargs):
     )
 
 
+def in_place_reshape(arr, newshape, reshaper, **kwargs):
+    to_array = np.asarray if reshaper is np.reshape else Tensor
+    arr = +arr  # "touch" array so we can check gradient
+
+    if isinstance(arr, Number):
+        arr = to_array(arr)
+
+    arr.shape = newshape
+    if isinstance(arr, Tensor) and kwargs.get("constant", False):
+        arr._constant = True
+    return arr
+
+
 @pytest.mark.parametrize(
     "reshape_type",
     [
@@ -49,6 +62,7 @@ def method_unpacked_reshape(arr, newshape, reshaper, **kwargs):
         keyword_reshape,
         method_tuple_reshape,
         method_unpacked_reshape,
+        in_place_reshape,
     ],
 )
 def test_reshape_fwd(reshape_type):
@@ -71,6 +85,7 @@ def test_reshape_fwd(reshape_type):
         keyword_reshape,
         method_tuple_reshape,
         method_unpacked_reshape,
+        in_place_reshape,
     ],
 )
 def test_reshape_bkwd(reshape_type):
@@ -80,7 +95,6 @@ def test_reshape_bkwd(reshape_type):
         num_arrays=1,
         kwargs=dict(newshape=lambda arrs: valid_shapes(arrs.size)),
         vary_each_element=True,
-        atol=1e-9,
     )
     def test_bkwd():
         pass


### PR DESCRIPTION
Closes #197 

- Generalizes in-place operations on `Tensor`
- Fixes inconsistent interface between `Tensor.reshape` and `numpy.reshape`
- Fixes inconsistent param name between `mygrad.reshape` and `numpy.reshape`
- Makes `.shape`  settable
- Greatly improve tests for `reshape`
- Rename confusing internal param name to be more descriptive