### PR TITLE
Add Average operation

### DIFF
--- a/src/mygrad/__init__.py
+++ b/src/mygrad/__init__.py
@@ -29,8 +29,6 @@ for attr in (
     cumprod,
     cumsum,
     mean,
-    _canonicalize_weights,
-    average,
     std,
     var,
     max,

--- a/src/mygrad/__init__.py
+++ b/src/mygrad/__init__.py
@@ -29,6 +29,8 @@ for attr in (
     cumprod,
     cumsum,
     mean,
+    _canonicalize_weights,
+    average,
     std,
     var,
     max,

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import mygrad
 from mygrad.tensor_base import Tensor
 
 from .ops import *
@@ -167,16 +168,14 @@ def _canonicalize_weights(x, axis, weights):
         return weights
     if axis is None:
         raise TypeError(
-            "Axis must be specified when shapes of a and weights "
-            "differ.")
+            "Axis must be specified when shapes of a and weights " "differ."
+        )
     if weights.ndim != 1:
-        raise TypeError(
-            "1D weights expected when shapes of a and weights differ.")
+        raise TypeError("1D weights expected when shapes of a and weights differ.")
     if weights.shape[0] != x.shape[axis]:
-        raise ValueError(
-            "Length of weights not compatible with specified axis.")
+        raise ValueError("Length of weights not compatible with specified axis.")
     # setup weights to broadcast along axis
-    weights = np.broadcast_to(weights, (x.ndim-1)*(1,) + weights.shape)
+    weights = mygrad.broadcast_to(weights, (x.ndim - 1) * (1,) + weights.shape)
     return weights.swapaxes(-1, axis)
 
 
@@ -187,12 +186,11 @@ def average(x, axis=None, weights=None, constant=False, returned=False):
         weights = _canonicalize_weights(x, axis, weights)
         scl = sum(weights, axis=axis, constant=constant)
         if np.any(scl == 0.0):
-            raise ZeroDivisionError(
-                "Weights sum to zero, can't be normalized")
+            raise ZeroDivisionError("Weights sum to zero, can't be normalized")
         avg = sum(x * weights, axis=axis, constant=constant) / scl
     if returned:
         if avg.shape != scl.shape:
-            scl = np.broadcast_to(scl, avg.shape)
+            scl = mygrad.broadcast_to(scl, avg.shape)
         return avg, scl
     else:
         return avg

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -168,7 +168,7 @@ def _canonicalize_weights(x, axis, weights):
         return weights
     if axis is None:
         raise TypeError(
-            "Axis must be specified when shapes of a and weights " "differ."
+            "Axis must be specified when shapes of a and weights differ."
         )
     if weights.ndim != 1:
         raise TypeError("1D weights expected when shapes of a and weights differ.")
@@ -181,13 +181,13 @@ def _canonicalize_weights(x, axis, weights):
 
 def average(x, axis=None, weights=None, constant=False, returned=False):
     if weights is None:
-        avg = mean(x, axis=axis, constant=constant)
-    else:
-        weights = _canonicalize_weights(x, axis, weights)
-        scl = sum(weights, axis=axis, constant=constant)
-        if np.any(scl == 0.0):
-            raise ZeroDivisionError("Weights sum to zero, can't be normalized")
-        avg = sum(x * weights, axis=axis, constant=constant) / scl
+        weights = Tensor(np.ones(x.shape, dtype=x.dtype))
+
+    weights = _canonicalize_weights(x, axis, weights)
+    scl = sum(weights, axis=axis, constant=constant)
+    if np.any(scl == 0.0):
+        raise ZeroDivisionError("Weights sum to zero, can't be normalized")
+    avg = sum(x * weights, axis=axis, constant=constant) / scl
     if returned:
         if avg.shape != scl.shape:
             scl = mygrad.broadcast_to(scl, avg.shape)

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -7,7 +7,6 @@ from .ops import *
 __all__ = [
     "sum",
     "mean",
-    "_canonicalize_weights",
     "average",
     "var",
     "std",

--- a/tests/math/sequence/test_sequential_funcs.py
+++ b/tests/math/sequence/test_sequential_funcs.py
@@ -7,7 +7,7 @@ import pytest
 from hypothesis import given, settings
 from pytest import raises
 
-import mygrad
+import mygrad as mg
 from mygrad import amax, amin, average, cumprod, cumsum, mean, prod, std, sum, var
 from mygrad.math.sequential.funcs import _canonicalize_weights
 
@@ -123,8 +123,8 @@ def test_min_bkwd():
 
 
 def test_min_max_aliases():
-    assert mygrad.max == amax
-    assert mygrad.min == amin
+    assert mg.max == amax
+    assert mg.min == amin
 
 
 @fwdprop_test_factory(
@@ -181,6 +181,18 @@ def test_average_fwd():
 def test_average_weights_zero_sum():
     with raises(ZeroDivisionError):
         average(np.array([1, 2]), weights=np.array([-1, 1]))
+
+
+def test_average_scl():
+    x = mg.Tensor(np.array([1, 2, 3, 4]))
+    weights = mg.Tensor(np.array([1, 2, 3, 4]))
+    avg, scl = average(x, weights=weights, returned=True)
+    expected_avg, expected_scl = np.average(x.data, weights=weights.data, returned=True)
+    assert np.isclose(avg.data, expected_avg)
+    assert np.isclose(scl.data, expected_scl)
+    scl.backward()
+    assert avg.grad is None
+    assert weights.grad is not None
 
 
 def test_canonicalize_weights():
@@ -282,8 +294,6 @@ def test_var_bkwd():
     )
 )
 def test_var_no_axis_fwd(x):
-    import mygrad as mg
-
     x = mg.Tensor(x, constant=False)
     o = mg.var(x, axis=())
     assert np.all(o.data == np.zeros_like(x.data))
@@ -297,8 +307,6 @@ def test_var_no_axis_fwd(x):
     )
 )
 def test_var_no_axis_bkwrd(x):
-    import mygrad as mg
-
     x = mg.Tensor(x, constant=False)
     mg.var(x, axis=()).backward()
     assert np.all(x.grad == np.zeros_like(x.data))
@@ -378,8 +386,6 @@ def test_std_bkwd():
     )
 )
 def test_std_no_axis_fwd(x):
-    import mygrad as mg
-
     x = mg.Tensor(x, constant=False)
     o = mg.std(x, axis=())
     assert np.all(o.data == np.zeros_like(x.data))
@@ -393,8 +399,6 @@ def test_std_no_axis_fwd(x):
     )
 )
 def test_std_no_axis_bkwrd(x):
-    import mygrad as mg
-
     x = mg.Tensor(x, constant=False)
     mg.std(x, axis=()).backward()
     assert np.all(x.grad == np.zeros_like(x.data))

--- a/tests/math/sequence/test_sequential_funcs.py
+++ b/tests/math/sequence/test_sequential_funcs.py
@@ -229,6 +229,23 @@ def test_average_bkwd():
     pass
 
 
+# Helps test the 2nd Tensor output of average.
+def average_returned_wrapper(average_func):
+    return lambda x, axis, weights: average_func(x, axis=axis, weights=weights, returned=True)[1]
+
+
+@backprop_test_factory(
+    mygrad_func=average_returned_wrapper(average),
+    true_func=average_returned_wrapper(np.average),
+    num_arrays=1,
+    kwargs=gen_average_args,
+    index_to_bnds={0: (-10, 10)},
+    vary_each_element=True,
+)
+def test_average_scl_bkwd():
+    pass
+
+
 @fwdprop_test_factory(
     mygrad_func=var,
     true_func=np.var,

--- a/tests/math/sequence/test_sequential_funcs.py
+++ b/tests/math/sequence/test_sequential_funcs.py
@@ -58,17 +58,17 @@ def gen_average_args(draw, arr):
         wt_shape = arr.shape
     else: # wt_1D
         # Only integer axis is supported for 1D weights
-        axis = draw(st.integers(min_value=0, max_value=len(arr.shape) - 1))
+        axis = draw(st.integers(min_value=-arr.ndim, max_value=arr.ndim - 1))
         wt_shape = (arr.shape[axis],)
     # Filter any axis summing up to 0 to avoid ZeroDivisionError
     wt_strat = hnp.arrays(
         dtype=np.float,
         shape=wt_shape,
-        elements=st.floats(allow_infinity=False, allow_nan=False, min_value=-10, max_value=10),
+        elements=st.floats(min_value=-10, max_value=10),
     ).filter(
         lambda wt: not np.isclose( _canonicalize_weights(arr, axis, wt).sum(axis=axis), 0).any()
     )
-    weights = draw(wt_strat | st.none())
+    weights = draw(st.none() | wt_strat)
     return dict(axis=axis, weights=weights)
 
 @fwdprop_test_factory(


### PR DESCRIPTION
**Background**
This is my attempt at implementing weighted average – see https://github.com/rsokl/MyGrad/issues/102.

**Example usage**
``` python3
>>> from mygrad import Tensor, average
>>> import numpy as np
>>> x = Tensor(np.array([[1, 10], [1, 10]]))
>>> weights = Tensor(np.array([[1, 1], [10, 1]]))
>>> avg, scl = average(x, axis=None, weights=weights, returned=True)
>>> type(avg), type(scl)
(<class 'mygrad.tensor_base.Tensor'>, <class 'mygrad.tensor_base.Tensor'>)
>>> avg.backward()
>>> x.grad
array([[0.07692308, 0.07692308],
       [0.76923077, 0.07692308]])
>>> weights.grad
array([[-0.10650888,  0.58579882],
       [-0.10650888,  0.58579882]])
```

**Rough edges**
- I don't like that `_canonicalize_weights` is exported from `sequential/funcs.py` – it's currently used for a hypothesis strategy + there are some tests targeting it.
- I feel like I have broken some patterns  – is it OK that `average` does not have an implementation in `sequential/ops.py`? I initially had an ops.py implementation, but I felt like the boilerplate did not add value.
- `average` documentation is missing: Should I copy over the numpy documentation and add some mygrad examples? 
- It would have been nice to have a linter command that I could run (which would apply black and isort on my files) – should I be running any autoformatters?
- The testing utility doesn't seem to support tuple outputs (as is the case when `returned=True`). The CI seems to have caught that I am not testing that branch (which is great).