### PR TITLE
Hotfix leaky relu test

### DIFF
--- a/tests/nnet/activations/test_leaky_relu.py
+++ b/tests/nnet/activations/test_leaky_relu.py
@@ -23,7 +23,7 @@ finite_floats = st.floats(allow_infinity=False, allow_nan=False)
 def _finite_params(arrs, slope):
     if isinstance(arrs, Tensor):
         arrs = arrs.data
-    return np.all(np.isfinite(slope * arrs))
+    return np.all(np.isfinite(slope * arrs)) and np.isfinite(slope * 10)
 
 
 @fwdprop_test_factory(


### PR DESCRIPTION
What's the right way to fix this? The issue is that the actual slope value is ok but the gradient being passed back through this operation is randomly in (-10, 10) which can cause an inf