### PR TITLE
Add normal initializer

### DIFF
--- a/src/mygrad/nnet/initializers/__init__.py
+++ b/src/mygrad/nnet/initializers/__init__.py
@@ -1,7 +1,9 @@
 from .constant import constant
 from .glorot_normal import glorot_normal
+from .normal import normal
 
 __all__ = [
     "constant",
     "glorot_normal",
+    "normal",
 ]

--- a/src/mygrad/nnet/initializers/normal.py
+++ b/src/mygrad/nnet/initializers/normal.py
@@ -1,0 +1,43 @@
+import numpy as np
+from mygrad import Tensor
+
+def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
+    """ Initialize a :class:`mygrad.Tensor` by drawing from a normal (Gaussian) distribution.
+
+    Parameters
+    ----------
+    shape : Sequence[int]
+        The output shape.
+
+    mean : Real, optional (default=0)
+        The mean of the distribution from which to draw.
+
+    std : Real, optional (default=1)
+        The standard deviation of the distribution from which to draw.
+
+    dtype : data-type, optional (default=float32)
+        The data type of the output tensor; must be a floating-point type.
+
+    constant : bool, optional (default=False)
+        If `True`, the returned tensor is a constant (it
+            does not back-propagate a gradient).
+
+    Returns
+    -------
+    mygrad.Tensor, shape=`shape`
+        A Tensor, with values drawn from Ɲ(μ, σ²), where μ=`mean` and σ=`std`.
+    """
+    if not np.issubdtype(dtype, np.floating):
+        raise ValueError("Glorot Normal initialization requires a floating-point dtype")
+    if std < 0:
+        raise ValueError("Standard deviation must be non-negative")
+
+    if len(shape) == 1:
+        shape = shape[0]
+
+    if isinstance(mean, Tensor):
+        mean = mean.item()
+    if isinstance(std, Tensor):
+        std = std.item()
+
+    return Tensor(np.random.normal(mean, std, shape), dtype=dtype, constant=constant)

--- a/src/mygrad/nnet/initializers/normal.py
+++ b/src/mygrad/nnet/initializers/normal.py
@@ -33,11 +33,11 @@ def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
     >>> from mygrad.nnet.initializers import normal
     >>> normal(1, 2, 3)
     Tensor([[[-0.06481607, -0.550582  ,  0.04689528],
-         [ 0.82973075,  2.83742   ,  1.0964519 ]]], dtype=float32)
+             [ 0.82973075,  2.83742   ,  1.0964519 ]]], dtype=float32)
 
     >>> normal(2, 2, dtype="float16", constant=True)
     Tensor([[-1.335 ,  0.9297],
-        [ 1.746 , -0.1222]], dtype=float16)
+            [ 1.746 , -0.1222]], dtype=float16)
 
     >>> normal(5, dtype="float64")
     Tensor([-0.03875407,  0.65368466, -0.72636993,  1.57404148, -1.17444345])

--- a/src/mygrad/nnet/initializers/normal.py
+++ b/src/mygrad/nnet/initializers/normal.py
@@ -1,6 +1,7 @@
 import numpy as np
 from mygrad import Tensor
 
+
 def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
     """ Initialize a :class:`mygrad.Tensor` by drawing from a normal (Gaussian) distribution.
 
@@ -26,6 +27,20 @@ def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
     -------
     mygrad.Tensor, shape=`shape`
         A Tensor, with values drawn from Ɲ(μ, σ²), where μ=`mean` and σ=`std`.
+
+    Examples
+    --------
+    >>> from mygrad.nnet.initializers import normal
+    >>> normal(1, 2, 3)
+    Tensor([[[-0.06481607, -0.550582  ,  0.04689528],
+         [ 0.82973075,  2.83742   ,  1.0964519 ]]], dtype=float32)
+
+    >>> normal(2, 2, dtype="float16", constant=True)
+    Tensor([[-1.335 ,  0.9297],
+        [ 1.746 , -0.1222]], dtype=float16)
+
+    >>> normal(5, dtype="float64")
+    Tensor([-0.03875407,  0.65368466, -0.72636993,  1.57404148, -1.17444345])
     """
     if not np.issubdtype(dtype, np.floating):
         raise ValueError("Glorot Normal initialization requires a floating-point dtype")

--- a/tests/nnet/initializers/test_normal.py
+++ b/tests/nnet/initializers/test_normal.py
@@ -1,0 +1,49 @@
+from hypothesis import given
+import hypothesis.strategies as st
+import hypothesis.extra.numpy as hnp
+import numpy as np
+import pytest
+
+from mygrad import Tensor
+from mygrad.nnet.initializers import normal
+
+
+@given(dtype=hnp.unsigned_integer_dtypes() | hnp.integer_dtypes() | hnp.complex_number_dtypes())
+def test_normal_dtype_validation(dtype):
+    with pytest.raises(ValueError):
+        normal(1, dtype=dtype)
+
+
+@given(std=st.floats(-1000, 0, exclude_max=True))
+def test_normal_std_validation(std):
+    with pytest.raises(ValueError):
+        normal(1, std=std)
+
+
+_array_shapes = ((1000000,), (1000, 100, 10), (10, 10, 10, 10, 10, 10))
+
+
+@given(
+    shape=st.sampled_from(_array_shapes),
+    mean=st.floats(-100, 100),
+    std=st.floats(0, 5),
+)
+def test_normal_statistics(shape, mean, std):
+    tensor = normal(shape, mean=mean, std=std)
+    assert isinstance(tensor, Tensor)
+    assert np.isclose(np.mean(tensor.data), mean, atol=1e-2)
+    assert np.isclose(np.std(tensor.data), std, atol=1e-2)
+
+
+@given(
+    shape=hnp.array_shapes(min_dims=2),
+    mean=st.floats(-100, 100),
+    std=st.floats(0, 100),
+    dtype=hnp.floating_dtypes(),
+    constant=st.booleans(),
+)
+def test_normal(shape, mean, std, dtype, constant):
+    tensor = normal(shape, mean=Tensor(mean), std=Tensor(std), dtype=dtype, constant=constant)
+    assert tensor.shape == shape
+    assert tensor.dtype == dtype
+    assert tensor.constant == constant


### PR DESCRIPTION
Last one :sweat_smile: 

Do we want to put `normal` and `uniform` into `tensor_creation` as well? Are we going to mirror `np.random` in the future?