### PR TITLE
Fully replace add.at in getitem

### DIFF
--- a/src/mygrad/tensor_core_ops/indexing.py
+++ b/src/mygrad/tensor_core_ops/indexing.py
@@ -88,8 +88,8 @@ class GetItem(Operation):
             ell_ind = -1
 
             # used to determine whether all integer array indices are next to one another or not
-            # stores [num int arrs, first int arr index, last int arr index]
-            contig_int_indices = [0, 0, 0]
+            # and if not, where indices must be inserted for broadcast compatability
+            pos_int_arr = []
 
             # tally objects
             for j, ind in enumerate(inds):
@@ -106,18 +106,13 @@ class GetItem(Operation):
                     continue
 
                 ind_arr = np.asarray(ind)
-                if np.issubdtype(ind_arr.dtype, np.bool_) and ind_arr.ndim > 1:
-                    num_bool_arr += ind_arr.ndim
+                if np.issubdtype(ind_arr.dtype, np.bool_):
+                    num_bool_arr += ind_arr.ndim - 1
                 elif np.issubdtype(ind_arr.dtype, np.int_):
                     num_int_arr = (
                         ind_arr.ndim if ind_arr.ndim > num_int_arr else num_int_arr
                     )
-
-                    contig_int_indices[0] += 1
-                    contig_int_indices[1] = (
-                        contig_int_indices[1] if contig_int_indices[1] else j
-                    )
-                    contig_int_indices[2] = j
+                    pos_int_arr.append(j)
 
             # expand ellipsis or add on omitted trailing slices
             missing_dims = a.ndim - num_bool_arr - len(inds) + num_none
@@ -129,20 +124,24 @@ class GetItem(Operation):
                 )
             elif missing_dims:
                 inds += [slice(None)] * missing_dims
-            print(missing_dims, a.ndim, num_bool_arr, len(inds), num_none)
 
-            if a.ndim == contig_int_indices[0] + num_int:
+            if a.ndim == len(pos_int_arr) + num_int:
                 # all dimensions indexed with integer arrays or integers
                 out_ind = np.ravel_multi_index(inds, a.shape, mode="wrap")
                 out = np.bincount(
                     out_ind.ravel(), weights=grad.ravel(), minlength=a.size
                 ).reshape(a.shape)
 
-            elif (
-                contig_int_indices[0]
-                == contig_int_indices[2] - contig_int_indices[1] + 1
-            ):
-                # all integer arrays next to one another
+            else:
+                # whether all integer arrays next to one another or not
+                # determines how new dims added to int array indices
+                if len(pos_int_arr):
+                    contig_int_arr = bool(
+                        len(pos_int_arr) == pos_int_arr[-1] - pos_int_arr[0]
+                    )
+                    if not contig_int_arr:
+                        diffs = list(zip(pos_int_arr[:-1], pos_int_arr[1:]))
+
                 offset = 0
                 out_ind = []
 
@@ -180,25 +179,42 @@ class GetItem(Operation):
                                 offset += 1
 
                         else:
-                            # integer arrays must already be broadcast compatible with
-                            # one another, so simply add trailing 1-dims
-                            # can ignore any leading 1-dims, as these will broadcast out
-                            # as needed or be undone in the subsequent ravel
-                            out_ind.append(ind.reshape(ind.shape + (1,) * offset))
-                            if a.ndim - j == contig_int_indices[1]:
-                                offset += num_int_arr
+                            if contig_int_arr:
+                                # integer arrays must already be broadcast compatible with
+                                # one another, so simply add trailing 1-dims
+                                # can ignore any leading 1-dims, as these will broadcast out
+                                # as needed or be undone in the subsequent ravel
+                                out_ind.append(ind.reshape(ind.shape + (1,) * offset))
+                                if a.ndim - j == pos_int_arr[0]:
+                                    offset += num_int_arr
+                            else:
+                                # add trailing indices for integer arrays
+                                ind = ind.reshape(
+                                    ind.shape
+                                    + (1,)
+                                    * (
+                                        a.ndim
+                                        - pos_int_arr[-1]
+                                        - num_bool_arr
+                                        + num_none
+                                        - 1
+                                    )
+                                )
+                                if len(diffs) > 0:
+                                    # add 1-dims for each dim between integer arrays
+                                    dims_to_add = tuple()
+                                    for i in diffs[1:]:
+                                        dims_to_add += tuple(range(*i))
+                                    diffs.pop()
+                                    ind = np.expand_dims(ind, dims_to_add)
+
+                                out_ind.append(ind)
+                                offset += 1
 
                 out_ind = np.ravel_multi_index(out_ind[::-1], a.shape, mode="wrap")
                 out = np.bincount(
                     out_ind.ravel(), weights=grad.ravel(), minlength=a.size
                 ).reshape(a.shape)
-
-            else:
-                # not all integer arrays next to one another
-                out = np.zeros_like(a.data)
-                # although `add.at` will work for all cases, it is
-                # a very slow function: https://github.com/numpy/numpy/issues/5922
-                np.add.at(out, self.index, grad)
         return out
 
 


### PR DESCRIPTION
This aims to fully phase out the use of `add.at` in the getitem backprop (as started in #265 ). The tests for `getitem`, however, cannot currently check all forms of advanced indexing, and I found a few simple cases in checking the function by hand that broke the code (those issues should be fixed).

~~I am going to work on making the tests for `getitem` more robust (e.g. check for slices, integer arrays, and boolean arrays in the same index). While these types of indexing will, for the most part, never be used, it's be nice to catch and correct any errors.~~ (see #271 for progress on this)

I also still need to do a better performance comparison of this implementation vs `add.at`. From my initial checks I noticed that for small arrays, `add.at` is slightly faster (a few μs) because of the additional logic here. For larger arrays, or when many values are being indexed (as is common when a slice is included), this tends to run a good bit faster. Again I will need to do look more in detail at how the runtime scales for this and for `add.at`