### PR TITLE
TravisCI has old LLVM for py36: ensure llvmlite < 34.0 is run for py36

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,11 @@ commands = pytest --hypothesis-profile ci \
 extras = rnn
 
 
+[testenv:py36]
+deps = {[testenv]deps}
+       llvmlite<34.0
+
+
 [testenv:coverage]
 passenv = CI TRAVIS TRAVIS_*
 setenv = NUMBA_DISABLE_JIT=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ extras = rnn
 
 [testenv:py36]
 deps = {[testenv]deps}
-       llvmlite<34.0
+       llvmlite<0.34
 
 
 [testenv:coverage]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ extras = rnn
 
 [testenv:py36]
 deps = {[testenv]deps}
-       llvmlite<0.34
+       numba==0.49.1
 
 
 [testenv:coverage]


### PR DESCRIPTION
Closes #275 