### PR TITLE
Demonstrate that python3 wants to warn you not to override __eq__ withou __hash__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# vim
+*.swp

--- a/src/mygrad/linalg/ops.py
+++ b/src/mygrad/linalg/ops.py
@@ -147,7 +147,7 @@ class EinSum(BroadcastableOp):
         # cache counts the number of redundant tensor-label pairs
         # fed to einsum. Only one gradient will be computed for a
         # unique tensor-label pair
-        self.cache = Counter(zip(variables, self.in_lbls))
+        self.cache = Counter(zip((id(v) for v in variables), self.in_lbls))
         return np.einsum(
             "->".join((in_lbls, out_lbls)),
             *(var.data for var in self.variables),
@@ -168,7 +168,7 @@ class EinSum(BroadcastableOp):
         original_var_lbl = in_lbls.pop(index)
         var = self.variables[index]
 
-        factor = self.cache[(var, original_var_lbl)]
+        factor = self.cache[(id(var), original_var_lbl)]
         if factor == 0:
             # the gradient for the current tensor-label pair
             # has already been computed, scaled, and back-propped,
@@ -176,7 +176,7 @@ class EinSum(BroadcastableOp):
             raise SkipGradient()
 
         numpy_arrays = tuple(i.data for i in self.variables)
-        self.cache[(var, original_var_lbl)] = 0
+        self.cache[(id(var), original_var_lbl)] = 0
 
         var_lbl = _unique_from_end(original_var_lbl)
         repeat_lbls = len(var_lbl) != len(original_var_lbl)

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -151,8 +151,10 @@ class Operation:
         # these by the node itself, since Tensors are unhashable, but by its `id`.
         visited = set()
         for var in (
-            i for i in self.variables if not i.constant and i.creator is not None and id(i) not in visited
+            i for i in self.variables if not i.constant and i.creator is not None
         ):
+            if id(var) in visited:
+                continue
             visited.add(id(var))
             var._accum_ops.add(self)
             var._backward(graph=graph)

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -147,9 +147,13 @@ class Operation:
                         var.grad += backed_grad
                     else:
                         var.grad += _reduction(backed_grad, var.shape)
+        # Avoid visiting the same node multiple times. Note that we don't store
+        # these by the node itself, since Tensors are unhashable, but by its `id`.
+        visited = set()
         for var in (
-            i for i in self.variables if not i.constant and i.creator is not None
+            i for i in self.variables if not i.constant and i.creator is not None and id(i) not in visited
         ):
+            visited.add(id(var))
             var._accum_ops.add(self)
             var._backward(graph=graph)
 

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -147,9 +147,9 @@ class Operation:
                         var.grad += backed_grad
                     else:
                         var.grad += _reduction(backed_grad, var.shape)
-        for var in {
+        for var in (
             i for i in self.variables if not i.constant and i.creator is not None
-        }:
+        ):
             var._accum_ops.add(self)
             var._backward(graph=graph)
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -979,6 +979,12 @@ class Tensor:
         """
         return self._op(Tensor_Transpose_Property, self)
 
+    def __eq__(self):
+        return np.ndarray.__eq__(x.data, y.data if isinstance(y, Tensor) else y)
+
+    def __ne__(self):
+        return np.ndarray.__ne__(x.data, y.data if isinstance(y, Tensor) else y)
+
 
 # set all comparison operators - mirrors ndarray methods
 def tensor_to_array_wrapper(func):
@@ -989,5 +995,5 @@ def tensor_to_array_wrapper(func):
     return wrapped
 
 
-for op in ("__lt__", "__le__", "__gt__", "__ge__", "__eq__", "__ne__"):
+for op in ("__lt__", "__le__", "__gt__", "__ge__"):
     setattr(Tensor, op, tensor_to_array_wrapper(getattr(np.ndarray, op)))

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -980,11 +980,11 @@ class Tensor:
         """
         return self._op(Tensor_Transpose_Property, self)
 
-    def __eq__(self):
-        return np.ndarray.__eq__(x.data, y.data if isinstance(y, Tensor) else y)
+    def __eq__(self, other):
+        return np.ndarray.__eq__(self.data, other.data if isinstance(other, Tensor) else other)
 
-    def __ne__(self):
-        return np.ndarray.__ne__(x.data, y.data if isinstance(y, Tensor) else y)
+    def __ne__(self, other):
+        return np.ndarray.__ne__(self.data, other.data if isinstance(other, Tensor) else other)
 
 
 # set all comparison operators - mirrors ndarray methods

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -445,7 +445,7 @@ class Tensor:
         if not clear_graph:
             assert isinstance(seen, set)
 
-            if self in seen:
+            if id(self) in seen:
                 return
 
         creator = self._creator
@@ -454,8 +454,9 @@ class Tensor:
             # marks tensor as "visited" during clear-graph traversal
             self._creator = None
         else:
-            # marks tensor as "visited" during null-gradients graph traversal
-            seen.add(self)
+            # marks tensor as "visited" during null-gradients graph traversal. Tensors are unhashable,
+            # so we use their ids, since we actually want to be relying on their uniqueness.
+            seen.add(id(self))
 
         for var in creator.variables:  # type: Tensor
             if clear_graph:

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -524,3 +524,14 @@ def test_clear_graph(x, y, z):
 
     with raises(InvalidBackprop):
         g.backward()
+
+# Tensor has its `__eq__` but not its `__hash__` overridden which leads to subtle
+# problems if it ends up being used in a hashable context. See
+# https://hynek.me/articles/hashes-and-equality/
+# for more details. This checks to make sure that anyone who does so will get an
+# error. See also https://github.com/rsokl/MyGrad/pull/276
+def test_no_hash():
+    try:
+        {Tensor(3): 'this should not work'}
+    except TypeError as e:
+        assert str(e) == "unhashable type: 'Tensor'"


### PR DESCRIPTION
Normally python would have made `Tensor` unhashable, but because this is being monkeypatched, it wasn't able to.

You would think this PR is a noop, but it'll cause a bunch of 'unhashable type: Tensor' errors

Ryan Edit:

Any class with `__eq__` defined will have that method be used to check hash-table collisions. `Tensor.__eq__` is based on its underlying numpy array, which is mutable. Also, this method returns an array, not a boolean – making it even more inappropriate. I.e. `Tensor` should have been unhashable.

`Tensor` _was_ hashable – and we relied on this hashability for doing BFS traversals of the computational graph – but this was a fluke. It was because `__eq__` and `__neq__` was getting monkeypatched after the `Tensor` definition. So basically, Python was falling back on its default behavior for providing bare classes with hashes: relying on object-id.

This PR replaces any reliance on hashing Tensor with hashing that tensor's id.   

☠️ relevant explanation  https://hynek.me/articles/hashes-and-equality/

and thanks to Alex for finding / explaining  all of this. I am rehashing it here for posterity.