### PR TITLE
remove ability to set Tensor.constant

### DIFF
--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -712,7 +712,7 @@ class Tensor:
         """
         return self.copy()
 
-    def copy(self, constant: Optional[None] = None) -> "Tensor":
+    def copy(self, constant: Optional[bool] = None) -> "Tensor":
         """ Produces a copy of ``self`` with ``copy.creator=None``.
 
         Copies of the underlying numpy data array and gradient array are created.

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -710,7 +710,7 @@ class Tensor:
         """
         return self.copy()
 
-    def copy(self, constant=Optional[None]) -> "Tensor":
+    def copy(self, constant: Optional[None] = None) -> "Tensor":
         """ Produces a copy of ``self`` with ``copy.creator=None``.
 
         Copies of the underlying numpy data array and gradient array are created.

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -550,14 +550,6 @@ class Tensor:
         """
         return self._constant
 
-    @constant.setter
-    def constant(self, value: bool):
-        if not isinstance(value, bool):
-            raise TypeError(
-                f"`Tensor.constant` must be set with a boolean, got : {type(value)}"
-            )
-        self._constant = value
-
     @property
     def creator(self) -> Union[Operation, BroadcastableOp]:
         """ The ``Operation`` instance that produced ``self``.
@@ -716,19 +708,19 @@ class Tensor:
         -------
         Tensor
         """
-        copy = Tensor(
-            np.copy(self.data),
-            _creator=None,
-            constant=self.constant,
-            _scalar_only=self._scalar_only,
-        )
-        copy.grad = np.copy(self.grad) if self.grad is not None else None
-        return copy
+        return self.copy()
 
-    def copy(self):
+    def copy(self, constant=Optional[None]) -> "Tensor":
         """ Produces a copy of ``self`` with ``copy.creator=None``.
 
         Copies of the underlying numpy data array and gradient array are created.
+
+        No information regarding the tensor's participation in the computational
+        graph are copied.
+
+        Parameters
+        ----------
+        constant : Optional[bool]
 
         Returns
         -------
@@ -748,7 +740,14 @@ class Tensor:
         >>> y_copy.creator is None
         True
         """
-        return self.__copy__()
+        copy = Tensor(
+            np.copy(self.data),
+            _creator=None,
+            constant=(self.constant if constant is None else constant),
+            _scalar_only=self._scalar_only,
+        )
+        copy.grad = np.copy(self.grad) if self.grad is not None else None
+        return copy
 
     def item(self):
         """ Copy an element of a tensor to a standard Python scalar and return it.

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -141,7 +141,9 @@ class Tensor:
             The operation-instance whose forward pass produced `self`. Should not
             be set manually by users.
         """
-        assert isinstance(constant, bool)
+        if not isinstance(constant, bool):
+            raise TypeError(f"`constant` must be a boolean value, got: {constant}")
+
         self._scalar_only = _scalar_only
         self._creator = _creator  # type: Union[None, Operation]
 

--- a/tests/state_testing/test_state.py
+++ b/tests/state_testing/test_state.py
@@ -31,7 +31,7 @@ def _node_ID_str(num):
     return "v{}".format(num + 1)
 
 
-@settings(max_examples=250, deadline=None)
+@settings(max_examples=125, stateful_step_count=100, deadline=None)
 class GraphCompare(RuleBasedStateMachine):
     def __init__(self):
         super().__init__()
@@ -81,15 +81,6 @@ class GraphCompare(RuleBasedStateMachine):
         n, t = items
         n.null_gradients(clear_graph=clear_graph)
         t.null_gradients(clear_graph=clear_graph)
-
-    @rule(items=nodes, constant=st.booleans())
-    def set_constant(self, items, constant):
-        """
-        Sets `.constant` on a random node
-        """
-        n, t = items
-        n.constant = constant
-        t.constant = constant
 
     @rule(items=nodes)
     def clear_graph(self, items):

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -12,6 +12,7 @@ from mygrad.errors import InvalidBackprop, InvalidGradient
 from mygrad.linalg.ops import MatMul
 from mygrad.math.arithmetic.ops import Add, Divide, Multiply, Negative, Power, Subtract
 from mygrad.operation_base import Operation
+from tests.custom_strategies import everything_except
 from tests.utils import does_not_raise
 
 
@@ -28,6 +29,12 @@ from tests.utils import does_not_raise
 def test_input_type_checking(data, constant, creator):
     with raises(TypeError):
         Tensor(data, constant=constant, _creator=creator)
+
+
+@given(constant=everything_except(bool))
+def test_input_constant_checking(constant):
+    with raises(TypeError):
+        Tensor(1.0, constant=constant)
 
 
 @given(

--- a/tests/tensor_ops/test_getitem.py
+++ b/tests/tensor_ops/test_getitem.py
@@ -1,10 +1,11 @@
 import hypothesis.extra.numpy as hnp
 import numpy as np
 from hypothesis import settings
-from mygrad.tensor_base import Tensor
 from numpy.testing import assert_allclose
 
-from ..custom_strategies import adv_integer_index, basic_indices, arbitrary_indices
+from mygrad.tensor_base import Tensor
+
+from ..custom_strategies import adv_integer_index, arbitrary_indices, basic_indices
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
@@ -30,7 +31,7 @@ def get_item(arr, index, constant=False):
         arr = np.asarray(arr)
     o = arr[index]
     if isinstance(o, Tensor):
-        o.constant = constant
+        o._constant = constant
 
     return o
 
@@ -54,7 +55,7 @@ def arb_index_wrap(*arrs):
 def test_index_empty():
     a = Tensor([])
     b = a[[]]
-    
+
     assert b.shape == (0,)
 
     b.sum().backward()

--- a/tests/tensor_ops/test_iter.py
+++ b/tests/tensor_ops/test_iter.py
@@ -20,7 +20,7 @@ def _sum(x, constant=False):
             # Hack to deal with summing over an empty tensor.
             # `sum(Tensor([]))` returns 0, which is fine
             out = Tensor(out)
-        out.constant = constant
+        out._constant = constant
     return out
 
 


### PR DESCRIPTION
Reverts #267 

There were tons of problems with setting Tensor.constant after it was already involved in a computational graph. The state-based testing found this, but needed to traverse deeper to find the problems consistently.

E.g.

```python
v1 = Tensor(0.)
v2 = +v1
v3 = Tensor(0.)
v4 = v3 - v2
v4.constant = True
v5 = v4 + v2

v5.backward()
```

would fail to clear `v2._accum_ops` during backprop. Another fail case: https://travis-ci.com/github/rsokl/MyGrad/jobs/372350422#L395

I considered only partially restricting the user's ability to set constant, but it just created too many headaches.

As an alternative, users can now use `Tensor.copy(constant)` to a similar, but sanitized, effect