### PR TITLE
Use __array__, which appears to be the standard way to expose a subclass's data

### DIFF
--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -100,8 +100,6 @@ def asarray(a, dtype=None, order=None) -> np.ndarray:
     >>> np.asanyarray(a) is a
     True
     """
-    if isinstance(a, Tensor):
-        a = a.data
     return np.asarray(a, dtype=dtype, order=order)
 
 
@@ -1064,6 +1062,9 @@ class Tensor:
         return np.ndarray.__ne__(
             self.data, other.data if isinstance(other, Tensor) else other
         )
+
+    def __array__(self, dtype=None):
+        return np.asarray(self.data, dtype)
 
 
 # set all comparison operators - mirrors ndarray methods

--- a/tests/numpy_compat/test_array_creation.py
+++ b/tests/numpy_compat/test_array_creation.py
@@ -48,9 +48,7 @@ def test_asarray_returns_array_with_expected_data_and_attributes(
     data = convert_input(array_data)
 
     actual = mg.asarray(data, dtype=dtype, order=order)
-    expected = np.asarray(
-        data if not isinstance(data, mg.Tensor) else data.data, dtype=dtype, order=order
-    )
+    expected = np.asarray(data, dtype=dtype, order=order)
 
     assert isinstance(actual, np.ndarray)
     assert_array_equal(actual, expected)
@@ -61,3 +59,14 @@ def test_asarray_returns_array_with_expected_data_and_attributes(
         order = "C"
 
     assert actual.flags[f"{order.capitalize()}_CONTIGUOUS"]
+
+# Test the third example from
+# https://numpy.org/doc/stable/reference/generated/numpy.asarray.html
+def test_asarray_copies_consistently():
+    a = mg.Tensor([1, 2], dtype=np.float32)
+
+    assert np.asarray(a, dtype=np.float32) is a.data
+    assert np.asarray(a, dtype=np.float64) is not a.data
+
+    assert mg.asarray(a, dtype=np.float32) is a.data
+    assert mg.asarray(a, dtype=np.float64) is not a.data


### PR DESCRIPTION
Exposes `Tensor.data` via `Tensor.__array__`, which enables a lot of cross-compatibility with numpy.

E.g.

```python
>>> import numpy as np
>>> import mygrad as mg
>>> np.equal(mg.arange(3), np.arange(3))
array([True, True, True
```