### PR TITLE
Add Tensor.base

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = [
 ]
 
 INSTALL_REQUIRES = ["numpy >= 1.12"]
-TESTS_REQUIRE = ["pytest >= 3.8", "hypothesis >= 4.53.2", "scipy"]
+TESTS_REQUIRE = ["pytest >= 3.8", "hypothesis >= 5.32.0", "scipy"]
 
 DESCRIPTION = "A sleek auto-differentiation library that wraps numpy."
 LONG_DESCRIPTION = """

--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -502,9 +502,13 @@ def multi_matmul(tensors, constant=False):
     # return proper shape since we possibly added dimensions to the first
     # and last arrays
     if ndim_first == 1 and ndim_last == 1:
-        return result[0, 0]
+        result = result[0, 0]
+        result._base = None  # result is only a view of an internal tensor
+        return result
     elif ndim_first == 1 or ndim_last == 1:
-        return result.reshape(-1)
+        result = result.reshape(-1)
+        result._base = None  # result is only a view of an internal tensor
+        return result
     else:
         return result
 

--- a/src/mygrad/math/arithmetic/ops.py
+++ b/src/mygrad/math/arithmetic/ops.py
@@ -20,6 +20,8 @@ __all__ = [
 
 
 class Add(BroadcastableOp):
+    cannot_return_view = True
+
     def __call__(self, a, b):
         """ Performs 'add' forward-pass: f(a,b) -> a + b
 
@@ -41,6 +43,8 @@ class Add(BroadcastableOp):
 
 
 class Subtract(BroadcastableOp):
+    cannot_return_view = True
+
     def __call__(self, a, b):
         """ f(a,b) -> a - b
 
@@ -64,6 +68,8 @@ class Subtract(BroadcastableOp):
 
 
 class Multiply(BroadcastableOp):
+    cannot_return_view = True
+
     def __call__(self, a, b):
         """ Parameters
             ----------
@@ -82,6 +88,8 @@ class Multiply(BroadcastableOp):
 
 
 class Divide(BroadcastableOp):
+    cannot_return_view = True
+
     def __call__(self, a, b):
         """ f(a, b) -> a / b"""
         self.variables = (a, b)
@@ -97,6 +105,8 @@ class Divide(BroadcastableOp):
 
 
 class Reciprocal(BroadcastableOp):
+    cannot_return_view = True
+
     def __call__(self, a):
         """ f(a) -> 1 / a"""
         self.variables = (a,)
@@ -108,6 +118,8 @@ class Reciprocal(BroadcastableOp):
 
 
 class Power(BroadcastableOp):
+    cannot_return_view = True
+
     def __call__(self, a, b):
         """ f(a, b) -> a ** b
 
@@ -129,6 +141,8 @@ class Power(BroadcastableOp):
 
 
 class Square(Operation):
+    cannot_return_view = True
+
     def __call__(self, a):
         """ f(a) -> a ** 2
 
@@ -144,6 +158,8 @@ class Square(Operation):
 
 class Positive(Operation):
     """ f(a) = +a """
+
+    cannot_return_view = True
 
     def __call__(self, a, where=True):
         """
@@ -164,6 +180,8 @@ class Positive(Operation):
 
 class Negative(Operation):
     """ f(a) = -a """
+
+    cannot_return_view = True
 
     def __call__(self, a, where=True):
         """

--- a/src/mygrad/math/sequential/ops.py
+++ b/src/mygrad/math/sequential/ops.py
@@ -42,7 +42,7 @@ class MaxMin(Operation):
         self.variables = (a,)
 
         if a.ndim == 0:
-            return a.data
+            return np.array(a.data)  # np.max does not permit views -> copy
 
         if hasattr(axis, "__iter__"):
             assert isinstance(axis, tuple)

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -47,6 +47,10 @@ class Operation:
     # the computational graph up to and including the present operation
     graph = None  # type: Optional[Set[Operation]]
 
+    # can be set to true if the operation is guaranteed to not returns a view
+    # this will reduce some overhead on checking for shared memory
+    cannot_return_view = False  # type: bool
+
     def __call__(self, *input_vars, **kwargs):  # pragma: no cover
         """ Performs a forward pass, f, of this Operation::
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -444,7 +444,7 @@ class Tensor:
                 if var._creator is not None and not var.constant
             )
         )
-        op_out = f(*tensor_vars, *op_args, **op_kwargs)
+        op_out = f(*tensor_vars, *op_args, **op_kwargs)  # type: np.ndarray
 
         if isinstance(f, BroadcastableOp) and not f.scalar_only:
             # if broadcasting occurred: scalar-only -> True
@@ -1019,7 +1019,7 @@ class Tensor:
         >>> y = x[2:]
         >>> y.base is x
         True
-        >>> y.data.base is x.base
+        >>> y.data.base is x.data
         True
 
         A view of a view has the same base as its "parent"

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1012,7 +1012,7 @@ class Tensor:
         The base of a tensor that owns its memory is ``None``:
 
         >>> import mygrad as mg
-        >>> x = mg.arange(5))  # creates a tensor with 3x5x2 (= 30) elements
+        >>> x = mg.arange(5)
         >>> x.base is None
         True
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -305,9 +305,12 @@ class Tensor:
             Signals that self.backward() can only be invoked if self.ndim == 0.
             Should not be set manually by users.
 
-        _creator: Optional[mygrad.Operation]
+        _creator : Optional[mygrad.Operation]
             The operation-instance whose forward pass produced `self`. Should not
             be set manually by users.
+
+        _base : Optional[Tensor]
+            Sets the base tensor that ``self`` is a view of
         """
         if not isinstance(constant, bool):
             raise TypeError(f"`constant` must be a boolean value, got: {constant}")
@@ -1025,6 +1028,16 @@ class Tensor:
 
         >>> z = y[:]
         >>> z.base is x
+        True
+
+        The behavior of ``Tensor.base`` departs from that of ``ndarray.base`` in that
+        mygrad will never create an "internal" tensor to serve as a base; e.g.
+
+        >>> import numpy as np
+        >>> np.reshape(2., (1,)).base
+        array(2.)
+
+        >>> mg.reshape(2., (1,)).base is None
         True
         """
         return self._base

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -801,6 +801,7 @@ class Tensor:
             constant=self.constant,
             _scalar_only=self._scalar_only,
             _creator=self.creator,
+            _base=self._base,
         )
         old_tensor._ops = self._ops
         old_tensor._accum_ops = self._accum_ops

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -6,7 +6,7 @@ etc., are bound to the Tensor class in ``mygrad.__init__.py``.
 
 from functools import wraps
 from numbers import Number
-from typing import Optional, Set, Type, Union
+from typing import Optional, Set, Tuple, Type, Union
 
 import numpy as np
 
@@ -386,7 +386,7 @@ class Tensor:
     def _op(
         cls,
         Op: Type[Operation],
-        *input_vars,
+        *input_vars: "Tensor",
         op_args=None,
         op_kwargs=None,
         constant=False,
@@ -465,9 +465,7 @@ class Tensor:
         if f.cannot_return_view:
             base = None
         else:
-            for can_share_mem, var in zip(
-                vars_can_share_mem, tensor_vars
-            ):  # type: Tensor
+            for can_share_mem, var in zip(vars_can_share_mem, tensor_vars):
                 if can_share_mem and np.shares_memory(var, op_out):
                     base = var if var.base is None else var.base
                     break

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -519,6 +519,8 @@ def valid_shapes(
     if not isinstance(size, int) or size < 0:
         raise ValueError(f"size={size} must be a non-negative integer")
 
+    if min_len == 0 and 1 < size:
+        min_len = 1
     shape_length = draw(st.integers(min_len, max_len))  # type: int
     shape = []  # type: List[int]
     rem = int(size / np.prod(shape))

--- a/tests/custom_strategies/test_strategies.py
+++ b/tests/custom_strategies/test_strategies.py
@@ -180,7 +180,7 @@ def test_factors(size: int):
     data=st.data(),
 )
 def test_valid_shapes(arr: np.ndarray, data: st.DataObject):
-    newshape = data.draw(valid_shapes(arr.size), label="newshape")
+    newshape = data.draw(valid_shapes(arr.size, min_len=0), label="newshape")
     arr.reshape(newshape)
 
 

--- a/tests/custom_strategies/test_strategies.py
+++ b/tests/custom_strategies/test_strategies.py
@@ -271,3 +271,9 @@ def test_tensors_with_grad(
         assert np.all((100 <= tensor.grad) & (tensor.grad <= 200))
     else:
         assert np.all((-10 <= tensor.grad) & (tensor.grad <= 10))
+
+
+@given(t=tensors())
+def test_tensor_owns_memory(t: Tensor):
+    assert t.base is None
+    assert t.data.base is None

--- a/tests/linalg/test_einsum.py
+++ b/tests/linalg/test_einsum.py
@@ -12,7 +12,7 @@ import mygrad as mg
 from mygrad import Tensor
 from mygrad.linalg.funcs import einsum
 
-from ..custom_strategies import array_shapes, broadcastable_shapes, tensors
+from ..custom_strategies import broadcastable_shapes, tensors
 from ..utils.numerical_gradient import numerical_gradient_full
 
 

--- a/tests/linalg/test_einsum.py
+++ b/tests/linalg/test_einsum.py
@@ -12,7 +12,7 @@ import mygrad as mg
 from mygrad import Tensor
 from mygrad.linalg.funcs import einsum
 
-from ..custom_strategies import broadcastable_shapes
+from ..custom_strategies import array_shapes, broadcastable_shapes, tensors
 from ..utils.numerical_gradient import numerical_gradient_full
 
 
@@ -466,3 +466,11 @@ def test_einsum_bkwd6(shape, optimize):
 
     assert_allclose(x.grad, dx, atol=1e-6)
     assert_allclose(y.grad, dy, atol=1e-6)
+
+
+@given(
+    x=tensors(shape=st.integers(1, 10).map(lambda x: (x, x))), optimize=st.booleans()
+)
+def test_einsum_can_produce_view(x: Tensor, optimize: bool):
+    y = mg.einsum("ii -> i", x, optimize=optimize)
+    assert y.base is x

--- a/tests/tensor_base/test_pow_special_cases.py
+++ b/tests/tensor_base/test_pow_special_cases.py
@@ -37,6 +37,7 @@ def test_pow_uses_special_case(power, op):
     true_func=custom_pow,
     num_arrays=1,
     kwargs={"p": partial(any_scalar, p=1)},
+    permit_0d_array_as_float=False,
 )
 def test_pow_1_fwd():
     pass
@@ -56,6 +57,7 @@ def test_pow_1_bkwd():
     mygrad_func=custom_pow,
     true_func=custom_pow,
     num_arrays=1,
+    permit_0d_array_as_float=False,
     kwargs={"p": partial(any_scalar, p=2)},
 )
 def test_pow_2_fwd():

--- a/tests/tensor_base/test_shares_memory.py
+++ b/tests/tensor_base/test_shares_memory.py
@@ -51,3 +51,8 @@ def test_tensor_base_matches_ndarray_base():
     a3 = arr + 1
     assert t3.base is None
     assert a3.base is None
+
+
+def test_views_of_non_arrays_leave_no_base():
+    assert mg.reshape(2.0, (1,)).base is None
+    assert mg.reshape(list(range(9)), (3, 3)).base is None

--- a/tests/tensor_base/test_shares_memory.py
+++ b/tests/tensor_base/test_shares_memory.py
@@ -25,3 +25,29 @@ def test_may_share_memory_works_with_tensors():
     assert not np.may_share_memory(x, mg.arange(10))
     assert not np.may_share_memory(x.copy(), y)
     assert not np.may_share_memory(x, y + 1)
+
+
+def test_tensor_base_matches_ndarray_base():
+    tens = mg.arange(10)
+    arr = np.arange(10)
+
+    assert tens.base is None
+    assert arr.base is None
+
+    t1 = tens[:5]
+    a1 = arr[:5]
+    assert t1.base is tens
+    assert t1.base.data is tens.data
+    assert a1.base is arr
+
+    t2 = t1[:2]
+    a2 = a1[:2]
+
+    assert t2.base is tens
+    assert t2.data.base is tens.data
+    assert a2.base is arr
+
+    t3 = tens + 1
+    a3 = arr + 1
+    assert t3.base is None
+    assert a3.base is None

--- a/tests/tensor_base/test_shares_memory.py
+++ b/tests/tensor_base/test_shares_memory.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+import mygrad as mg
+
+
+def test_shares_memory_works_with_tensors():
+    x = mg.arange(10)
+    y = x[:2]
+    assert np.shares_memory(x, y)
+    assert np.shares_memory(x.data, y)
+    assert np.shares_memory(x, y.data)
+    assert np.shares_memory(x.data, y.data)
+    assert not np.shares_memory(x, mg.arange(10))
+    assert not np.shares_memory(x.copy(), y)
+    assert not np.shares_memory(x, y + 1)
+
+
+def test_may_share_memory_works_with_tensors():
+    x = mg.arange(10)
+    y = x[:2]
+    assert np.may_share_memory(x, y)
+    assert np.may_share_memory(x.data, y)
+    assert np.may_share_memory(x, y.data)
+    assert np.may_share_memory(x.data, y.data)
+    assert not np.may_share_memory(x, mg.arange(10))
+    assert not np.may_share_memory(x.copy(), y)
+    assert not np.may_share_memory(x, y + 1)

--- a/tests/tensor_ops/test_getitem.py
+++ b/tests/tensor_ops/test_getitem.py
@@ -27,8 +27,6 @@ def test_getitem():
 
 
 def get_item(arr, index, constant=False):
-    if not isinstance(arr, Tensor):
-        arr = np.asarray(arr)
     o = arr[index]
     if isinstance(o, Tensor):
         o._constant = constant
@@ -70,6 +68,14 @@ def test_index_0d():
     assert Tensor(3)[None].item() == 3
 
 
+def test_getitem_view_base():
+    x = Tensor(np.asarray(0.0))
+    o = x[(Ellipsis,)]
+    assert o.data.base is o.base.data
+    assert np.shares_memory(o, x.data)
+    assert np.shares_memory(o, x)
+
+
 @fwdprop_test_factory(
     mygrad_func=get_item,
     true_func=get_item,
@@ -78,6 +84,7 @@ def test_index_0d():
         0: hnp.array_shapes(min_side=0, min_dims=0, max_side=6, max_dims=4)
     },
     kwargs=dict(index=basic_index_wrap),
+    permit_0d_array_as_float=False,
 )
 def test_getitem_basicindex_fwdprop():
     pass
@@ -259,6 +266,7 @@ def test_getitem_basic_w_adv_bkprop():
         0: hnp.array_shapes(min_side=0, max_side=4, min_dims=0, max_dims=5)
     },
     kwargs=dict(index=arb_index_wrap),
+    permit_0d_array_as_float=False,
 )
 def test_getitem_arbitraryindex_fwdprop():
     pass

--- a/tests/tensor_ops/test_iter.py
+++ b/tests/tensor_ops/test_iter.py
@@ -1,4 +1,5 @@
 import hypothesis.extra.numpy as hnp
+import numpy as np
 import pytest
 
 from mygrad.tensor_base import Tensor
@@ -21,6 +22,8 @@ def _sum(x, constant=False):
             # `sum(Tensor([]))` returns 0, which is fine
             out = Tensor(out)
         out._constant = constant
+    else:
+        out = np.asarray(out)  # ensure numpy-output is array
     return out
 
 


### PR DESCRIPTION
This PR adds rudimentary functionality for tracking views of tensors. This is the beginnings of adding support for completely generic in-place updates on views of tensors.

Like `ndarray.base`, `Tensor.base` provides the ability to track views of Tensors. 

The base of a tensor that owns its memory is `None`:

```python
>>> import mygrad as mg
>>> x = mg.arange(5)
>>> x.base is None
True
```

Slicing creates a view, whose memory is shared with `x`:

```python
>>> y = x[2:]
>>> y.base is x
True
>>> y.data.base is x.data
True
```

A view of a view has the same base as its "parent"

```python
>>> z = y[:]
>>> z.base is x
True
```

The behavior of `Tensor.base` departs from that of `ndarray.base` in that
mygrad will never create an "internal" tensor to serve as a base; e.g.

```python
>>> import numpy as np
>>> np.reshape(2., (1,)).base  # creates `array(2.)` internally and treats the output as a view of it
array(2.)

>>> mg.reshape(2., (1,)).base is None
True
```

Fortunately, we were already doing a good job of preserving views of arrays, so mygrad already has very good parity with numpy for those functions that return views and those that do not.


Lastly, `tensor.base` points to the base *Tensor-instance*, not the base ndarray.

```python
>>> arr = np.arange(10)
>>> arr2 = arr[:]  # a view of `arr`
>>> tensor = Tensor(arr2)
>>> tensor.base is None
True
>>> tensor[:].base.data is arr2  # the base of tensor[:] is tensor, whose data is arr2
True
```