### PR TITLE
Pearl clutching memory management

### DIFF
--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -503,11 +503,9 @@ def multi_matmul(tensors, constant=False):
     # and last arrays
     if ndim_first == 1 and ndim_last == 1:
         result = result[0, 0]
-        result._base = None  # result is only a view of an internal tensor
         return result
     elif ndim_first == 1 or ndim_last == 1:
         result = result.reshape(-1)
-        result._base = None  # result is only a view of an internal tensor
         return result
     else:
         return result

--- a/src/mygrad/nnet/activations/glu.py
+++ b/src/mygrad/nnet/activations/glu.py
@@ -40,9 +40,9 @@ def glu(x, axis=-1, constant=False):
     --------
     >>> import mygrad as mg
     >>> from mygrad.nnet.activations import glu
-    >>> x = mg.arange(-5, 5)
+    >>> x = mg.arange(-5., 5.)
     >>> x
-    Tensor([-5, -4, -3, -2, -1,  0,  1,  2,  3,  4])
+    Tensor([-5., -4., -3., -2., -1.,  0.,  1.,  2.,  3.,  4.])
     >>> y = glu(x); y
     Tensor([-2.5       , -2.92423431, -2.64239123, -1.90514825, -0.98201379])
     >>> y.backward()

--- a/src/mygrad/nnet/initializers/glorot_normal.py
+++ b/src/mygrad/nnet/initializers/glorot_normal.py
@@ -54,4 +54,9 @@ def glorot_normal(*shape, gain=1, dtype=np.float32, constant=False):
     fan_in = shape[1] * (shape[-1] if len(shape) > 2 else 1)
     fan_out = shape[0] * (shape[-1] if len(shape) > 2 else 1)
     std = gain * np.sqrt(2 / (fan_in + fan_out))
-    return Tensor(np.random.normal(0, std, shape), dtype=dtype, constant=constant)
+    return Tensor(
+        np.random.normal(0, std, shape),
+        dtype=dtype,
+        constant=constant,
+        _copy_data=False,
+    )

--- a/src/mygrad/nnet/initializers/normal.py
+++ b/src/mygrad/nnet/initializers/normal.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from mygrad import Tensor
 
 
@@ -55,4 +56,9 @@ def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
     if isinstance(std, Tensor):
         std = std.item()
 
-    return Tensor(np.random.normal(mean, std, shape), dtype=dtype, constant=constant)
+    return Tensor(
+        np.random.normal(mean, std, shape),
+        dtype=dtype,
+        constant=constant,
+        _copy_data=False,
+    )

--- a/src/mygrad/nnet/initializers/uniform.py
+++ b/src/mygrad/nnet/initializers/uniform.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from mygrad import Tensor
 
 
@@ -55,4 +56,9 @@ def uniform(*shape, lower_bound=0, upper_bound=1, dtype=np.float32, constant=Fal
     if isinstance(upper_bound, Tensor):
         upper_bound = upper_bound.item()
 
-    return Tensor(np.random.uniform(lower_bound, upper_bound, shape), dtype=dtype, constant=constant)
+    return Tensor(
+        np.random.uniform(lower_bound, upper_bound, shape),
+        dtype=dtype,
+        constant=constant,
+        _copy_data=False,
+    )

--- a/src/mygrad/random/funcs.py
+++ b/src/mygrad/random/funcs.py
@@ -32,7 +32,7 @@ def rand(*shape, constant=False):
             [0.66029533, 0.79285341, 0.54967228, 0.25178508]])
     """
 
-    return Tensor(np.random.rand(*shape), constant=constant)
+    return Tensor(np.random.rand(*shape), constant=constant, _copy_data=False)
 
 
 def randint(low, high=None, shape=None, dtype=int, constant=False):
@@ -79,7 +79,9 @@ def randint(low, high=None, shape=None, dtype=int, constant=False):
     Tensor(57)
     """
 
-    return Tensor(np.random.randint(low, high, shape, dtype), constant=constant)
+    return Tensor(
+        np.random.randint(low, high, shape, dtype), constant=constant, _copy_data=False
+    )
 
 
 def randn(*shape, constant=False):
@@ -118,7 +120,7 @@ def randn(*shape, constant=False):
              [-1.28788909, -1.52525778]]])
     """
 
-    return Tensor(np.random.randn(*shape), constant=constant)
+    return Tensor(np.random.randn(*shape), constant=constant, _copy_data=False)
 
 
 def random(shape=None, constant=False):
@@ -151,7 +153,7 @@ def random(shape=None, constant=False):
             [0.19780163, 0.51162365, 0.7849505 , 0.47864586]])
     """
 
-    return Tensor(np.random.random(shape), constant=constant)
+    return Tensor(np.random.random(shape), constant=constant, _copy_data=False)
 
 
 def random_sample(shape=None, constant=False):
@@ -190,7 +192,7 @@ def random_sample(shape=None, constant=False):
     Tensor(0.47644928)
     """
 
-    return Tensor(np.random.random_sample(shape), constant=constant)
+    return Tensor(np.random.random_sample(shape), constant=constant, _copy_data=False)
 
 
 def ranf(shape=None, constant=False):
@@ -231,7 +233,7 @@ def ranf(shape=None, constant=False):
     Tensor(0.77739196)
     """
 
-    return Tensor(np.random.ranf(shape), constant=constant)
+    return Tensor(np.random.ranf(shape), constant=constant, _copy_data=False)
 
 
 def sample(shape=None, constant=False):
@@ -268,11 +270,13 @@ def sample(shape=None, constant=False):
     Tensor(0.50690423)
     """
 
-    return Tensor(np.random.sample(shape), constant=constant)
+    return Tensor(np.random.sample(shape), constant=constant, _copy_data=False)
 
 
 def seed(seed_number):
-    """ Seed the generator
+    """ Seed the generator.
+
+    Simply used NumPy's random state - i.e. this is equivalent to ``numpy.random.seed``.
 
     Parameters
     ----------

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -503,15 +503,21 @@ class Tensor:
         for var in tensor_vars:
             scalar_only = scalar_only or (var.scalar_only and not var.constant)
 
+        # determine whether or not op was a view
         if f.cannot_return_view:
             base = None
         else:
             for can_share_mem, var in zip(vars_can_share_mem, tensor_vars):
                 if can_share_mem and np.shares_memory(var, op_out):
                     base = var if var.base is None else var.base
+                    assert not f.cannot_return_view, (
+                        f"{f} is marked as being unable to return a view, "
+                        f"however its output is a view of one of its inputs"
+                    )
                     break
             else:
                 base = None
+
         return cls(
             op_out,
             constant=is_const,

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -6,7 +6,7 @@ etc., are bound to the Tensor class in ``mygrad.__init__.py``.
 
 from functools import wraps
 from numbers import Number
-from typing import Optional, Set, Tuple, Type, Union
+from typing import Optional, Set, Type, Union
 
 import numpy as np
 
@@ -251,7 +251,7 @@ class Tensor:
     >>> f.grad
     array(1.0)  # df/df
 
-    Once the gradient is computed, the computational graph containing ``x``,
+    Once the gradients are computed, the computational graph containing ``x``,
     ``y``, and ``f`` is cleared automatically. Additionally, involving any
     of these tensors in a new computational graph will automatically null
     their gradients.

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -292,7 +292,7 @@ class Tensor:
         _scalar_only=False,
         _creator=None,
         _base: Optional["Tensor"] = None,
-        _copy_data: bool = None,
+        _copy_data: Optional[bool] = None,
     ):
         """
         Parameters
@@ -320,6 +320,9 @@ class Tensor:
 
         _base : Optional[Tensor]
             Sets the base tensor that ``self`` is a view of
+
+        _copy_data : Optional[bool]
+            Determines if the incoming array-data will be copied
         """
         if not isinstance(constant, bool):
             raise TypeError(f"`constant` must be a boolean value, got: {constant}")

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -109,7 +109,7 @@ def astensor(t, dtype=None, constant=None) -> "Tensor":
     A tensor `t` is returned unchanged - its gradient and computational
     graph state preserved - if dtype and constant are compatible.
     A copy of the underlying numpy array is created only if dtype is
-    incompatible.
+    incompatible or if a non-constant tensor is being created from a constant.
 
     Parameters
     ----------
@@ -169,8 +169,15 @@ def astensor(t, dtype=None, constant=None) -> "Tensor":
     >>> mg.astensor(t, dtype=np.float64) is t
     False
 
-    If `constant` is set, a new tensor is created (with no copy
-    of the underlying data) only if constant doesn't match.
+    Creating a non-constant tensor from a constant tensor will copy
+    the underlying data.
+
+    >>> t = mg.Tensor([1, 2], constant=True)
+    >>> mg.astensor(t, constant=False).data is t.data
+    False
+
+    Otherwise, if `constant` is set, a new tensor is created (with
+    no copy of the underlying data) only if constant doesn't match.
 
     >>> t = mg.Tensor([1, 2], constant=False)
     >>> mg.astensor(t, constant=False) is t
@@ -223,6 +230,19 @@ class Tensor:
     >>> mg.arange(4)    # using numpy-style tensor creation functions
     Tensor([0, 1, 2, 3])
 
+    Creating a non-constant tensor will copy array data:
+
+    >>> import numpy as np
+    >>> arr = np.arange(10.)
+    >>> t_var = Tensor(arr, constant=False)
+    >>> np.shares_memory(arr, t_var)
+    False
+
+    Creating constant tensor will not make a copy of the array data:
+
+    >>> t_const = Tensor(arr, constant=True)
+    >>> np.shares_memory(arr, t_const)
+    True
 
     Forward and Back-Propagation
     ----------------------------

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -347,6 +347,11 @@ class Tensor:
         if not isinstance(constant, bool):
             raise TypeError(f"`constant` must be a boolean value, got: {constant}")
 
+        assert isinstance(_scalar_only, bool)
+        assert isinstance(_creator, (Operation, type(None)))
+        assert isinstance(_base, (Tensor, type(None)))
+        assert isinstance(_copy_data, (bool, type(None)))
+
         self._scalar_only = _scalar_only
         self._creator = _creator  # type: Union[None, Operation]
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -31,6 +31,15 @@ from mygrad.tensor_manip.transpose_like.ops import Tensor_Transpose_Property
 __all__ = ["Tensor", "asarray"]
 
 
+def _is_view_of(parent: "Tensor", child: np.ndarray) -> bool:
+    if np.shares_memory(parent, child):
+        return True
+    elif child.size == 0 and child.base is not None:
+        if (child.base is parent.data) or (child.base is parent.data.base):
+            return True
+    return False
+
+
 def asarray(a, dtype=None, order=None) -> np.ndarray:
     """Convert the input to an array.
 
@@ -558,7 +567,7 @@ class Tensor:
             base = None
         else:
             for can_share_mem, var in zip(vars_can_share_mem, tensor_vars):
-                if can_share_mem and np.shares_memory(var, op_out):
+                if can_share_mem and _is_view_of(parent=var, child=op_out):
                     base = var if var.base is None else var.base
                     assert not f.cannot_return_view, (
                         f"{f} is marked as being unable to return a view, "

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -756,13 +756,13 @@ class Tensor:
         import warnings
 
         warnings.warn(
-            "`tensor.null_gradients()` is deprecated. A tensor will automatically "
-            "have its gradient nulled if you use it in a new computational graph.",
-            DeprecationWarning,
+            "`tensor.null_gradients()` is deprecated. Calling it will raise an error "
+            "in future versions of MyGrad. A tensor will automatically "
+            "have its gradient nulled if you use it in a new computational graph. "
+            "Or, you can call `tensor.null_grad()` to null that individual tensor's "
+            "gradient.",
+            FutureWarning,
         )
-        if clear_graph:  # pragma: no cover
-            self.clear_graph()
-        return None
 
     def clear_graph(self):
         """

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -414,7 +414,8 @@ class Tensor:
             # Furthermore, the parent's writeability must be restored before
             # restoring the view's writeability
             self.base._restore_writeability()
-            self.data.flags.writeable = self.base.data.flags.writeable
+            if self.base.data.flags.writeable:
+                self.data.flags.writeable = self.base.data.flags.writeable
             return
 
         if self._data_was_writeable is None:
@@ -422,10 +423,12 @@ class Tensor:
 
         # the base-data's writeability must be restored before that of its view's
         if self._base_data_was_writeable is not None:
-            self.data.base.flags.writeable = self._base_data_was_writeable
+            if self._base_data_was_writeable:
+                self.data.base.flags.writeable = self._base_data_was_writeable
             self._base_data_was_writeable = None
 
-        self.data.flags.writeable = self._data_was_writeable
+        if self._data_was_writeable:
+            self.data.flags.writeable = self._data_was_writeable
         self._data_was_writeable = None
 
     def astype(

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -555,11 +555,9 @@ class Tensor:
                 op_out.shape != i.shape for i in tensor_vars if not i.constant
             )
 
-        if not is_const:
-            # record that a variable participated in that op
-            for var in tensor_vars:
-                if not var.constant:
-                    var._ops.add(f)
+        # record that a variable participated in that op
+        for var in tensor_vars:
+            var._ops.add(f)
 
         scalar_only = f.scalar_only and not is_const
         for var in tensor_vars:
@@ -787,7 +785,7 @@ class Tensor:
             var.clear_graph()
 
     @property
-    def scalar_only(self):
+    def scalar_only(self) -> bool:
         """ Indicates whether or not `self.ndim` must be 0 in order to invoke `self.backward()`.
 
         E.g. a computational graph that involves a broadcast-multiplication of a non-constant
@@ -953,11 +951,6 @@ class Tensor:
         self._mirror_tensor(out)
 
     def __setitem__(self, key, value):
-        if self.constant and (not isinstance(value, Tensor) or value.constant):
-            self.data[key] = value.data if isinstance(value, Tensor) else value
-            return None
-
-        # self becomes the tensor post-setitem
         self._in_place_op(SetItem, value, op_args=(key,))
 
     def __add__(self, other):
@@ -1056,9 +1049,7 @@ class Tensor:
         """
         copy = Tensor(
             np.copy(self.data),
-            _creator=None,
             constant=(self.constant if constant is None else constant),
-            _scalar_only=self._scalar_only,
         )
         copy.grad = np.copy(self.grad) if self.grad is not None else None
         return copy

--- a/src/mygrad/tensor_core_ops/indexing.py
+++ b/src/mygrad/tensor_core_ops/indexing.py
@@ -125,7 +125,7 @@ class SetItem(BroadcastableOp):
             `index` contains any integer-valued arrays, to accommodate for the scenario
             in which a single element is set multiple times."""
 
-        out = np.copy(a.data) if not a.constant else a.data
+        out = np.copy(a.data)
         self.variables = (a, b)
         self.index = index if isinstance(index, tuple) else (index,)
         out[index] = b.data

--- a/src/mygrad/tensor_creation/funcs.py
+++ b/src/mygrad/tensor_creation/funcs.py
@@ -66,7 +66,7 @@ def empty(shape, dtype=np.float32, constant=False):
         Tensor([[-1073741821, -1067949133],
                 [  496041986,    19249760]])                     #random
     """
-    return Tensor(np.empty(shape, dtype), constant=constant)
+    return Tensor(np.empty(shape, dtype), constant=constant, _copy_data=False)
 
 
 def empty_like(other, dtype=None, constant=False):
@@ -101,7 +101,9 @@ def empty_like(other, dtype=None, constant=False):
         Tensor([[-1073741821, -1067949133],
                 [  496041986,    19249760]])                     #random
     """
-    return Tensor(np.empty_like(asarray(other), dtype), constant=constant)
+    return Tensor(
+        np.empty_like(asarray(other), dtype), constant=constant, _copy_data=False
+    )
 
 
 def eye(rows, cols=None, diag_idx=0, dtype=np.float32, constant=False):
@@ -142,7 +144,9 @@ def eye(rows, cols=None, diag_idx=0, dtype=np.float32, constant=False):
                 [ 0.,  0.,  1.],
                 [ 0.,  0.,  0.]])
     """
-    return Tensor(np.eye(rows, cols, diag_idx, dtype), constant=constant)
+    return Tensor(
+        np.eye(rows, cols, diag_idx, dtype), constant=constant, _copy_data=False
+    )
 
 
 def identity(n, dtype=np.float32, constant=False):
@@ -173,7 +177,7 @@ def identity(n, dtype=np.float32, constant=False):
                 [ 0.,  1.,  0.],
                 [ 0.,  0.,  1.]])
     """
-    return Tensor(np.identity(n, dtype), constant=constant)
+    return Tensor(np.identity(n, dtype), constant=constant, _copy_data=False)
 
 
 def ones(shape, dtype=np.float32, constant=False):
@@ -222,7 +226,7 @@ def ones(shape, dtype=np.float32, constant=False):
     Tensor([[ 1.,  1.],
             [ 1.,  1.]])
     """
-    return Tensor(np.ones(shape, dtype), constant=constant)
+    return Tensor(np.ones(shape, dtype), constant=constant, _copy_data=False)
 
 
 def ones_like(other, dtype=None, constant=False):
@@ -265,7 +269,9 @@ def ones_like(other, dtype=None, constant=False):
     >>> mg.ones_like(y)
     Tensor([ 1.,  1.,  1.])
     """
-    return Tensor(np.ones_like(asarray(other), dtype), constant=constant)
+    return Tensor(
+        np.ones_like(asarray(other), dtype), constant=constant, _copy_data=False
+    )
 
 
 def zeros(shape, dtype=np.float32, constant=False):
@@ -313,7 +319,7 @@ def zeros(shape, dtype=np.float32, constant=False):
     Tensor([[ 0.,  0.],
             [ 0.,  0.]])
     """
-    return Tensor(np.zeros(shape, dtype), constant=constant)
+    return Tensor(np.zeros(shape, dtype), constant=constant, _copy_data=False)
 
 
 def zeros_like(other, dtype=None, constant=False):
@@ -363,7 +369,9 @@ def zeros_like(other, dtype=None, constant=False):
     >>> mg.zeros_like(y)
     Tensor([ 0.,  0.,  0.])
     """
-    return Tensor(np.zeros_like(asarray(other), dtype), constant=constant)
+    return Tensor(
+        np.zeros_like(asarray(other), dtype), constant=constant, _copy_data=False
+    )
 
 
 def full(shape, fill_value, dtype=None, constant=False):
@@ -401,7 +409,9 @@ def full(shape, fill_value, dtype=None, constant=False):
     Tensor([[10, 10],
             [10, 10]])
     """
-    return Tensor(np.full(shape, fill_value, dtype), constant=constant)
+    return Tensor(
+        np.full(shape, fill_value, dtype), constant=constant, _copy_data=False
+    )
 
 
 def full_like(other, fill_value, dtype=None, constant=False):
@@ -441,7 +451,11 @@ def full_like(other, fill_value, dtype=None, constant=False):
         >>> mg.full_like(y, 0.1)
         Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
     """
-    return Tensor(np.full_like(asarray(other), fill_value, dtype), constant=constant)
+    return Tensor(
+        np.full_like(asarray(other), fill_value, dtype),
+        constant=constant,
+        _copy_data=False,
+    )
 
 
 def arange(stop, start=0, step=1, dtype=None, constant=False):
@@ -489,7 +503,9 @@ def arange(stop, start=0, step=1, dtype=None, constant=False):
         tmp = start
         start = stop
         stop = tmp
-    return Tensor(np.arange(start, stop, step, dtype), constant=constant)
+    return Tensor(
+        np.arange(start, stop, step, dtype), constant=constant, _copy_data=False
+    )
 
 
 def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=False):
@@ -540,7 +556,9 @@ def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=Fa
         Tensor([ 2. ,  2.2,  2.4,  2.6,  2.8])
     """
     return Tensor(
-        np.linspace(start, stop, num, include_endpoint, dtype=dtype), constant=constant
+        np.linspace(start, stop, num, include_endpoint, dtype=dtype),
+        constant=constant,
+        _copy_data=False,
     )
 
 
@@ -603,7 +621,9 @@ def logspace(
             A Tensor of `num` evenly-spaced values in the log interval [base**start, base**stop].
     """
     return Tensor(
-        np.logspace(start, stop, num, include_endpoint, base, dtype), constant=constant
+        np.logspace(start, stop, num, include_endpoint, base, dtype),
+        constant=constant,
+        _copy_data=False,
     )
 
 
@@ -676,5 +696,7 @@ def geomspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=F
         Tensor([-1000.,  -100.,   -10.,    -1.])
     """
     return Tensor(
-        np.geomspace(start, stop, num, include_endpoint, dtype), constant=constant
+        np.geomspace(start, stop, num, include_endpoint, dtype),
+        constant=constant,
+        _copy_data=False,
     )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+from numpy import ndarray
+
+import mygrad as mg
+
+
+def as_numpy(x: mg.Tensor) -> ndarray:
+    """Utility for leveraging mygrad ops without incurring locked memory"""
+    x.clear_graph()
+    return mg.asarray(x)

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -101,6 +101,7 @@ def tensors(
     include_grad: Union[bool, st.SearchStrategy[bool]] = False,
     grad_dtype: Optional[Any] = None,
     grad_elements_bounds: Optional[Tuple[int, int]] = None,
+    read_only: Union[bool, st.SearchStrategy[bool]] = False,
 ) -> st.SearchStrategy[Tensor]:
     r"""Returns a strategy for generating :class:`mygrad:mygrad.Tensor`\ s.
 
@@ -154,6 +155,9 @@ def tensors(
         Defaults to (-10, 10)
         Specifying ``grad_element_bounds``, while ``include_grad`` is False, will raise an error.
 
+    read_only: Union[bool, st.SearchStrategy[bool]]
+        If True, the underlying numpy array is marked as not-writeable.
+
     Returns
     -------
     st.SearchStrategy[Tensor]
@@ -202,11 +206,18 @@ def tensors(
     hundreds or more elements, having a fill value is essential if you want
     your tests to run in reasonable time.
     """
+    assert isinstance(read_only, (bool, st.SearchStrategy))
+    if isinstance(read_only, st.SearchStrategy):
+        read_only = draw(read_only)
+
     x = draw(
         hnp.arrays(
             dtype=dtype, shape=shape, elements=elements, fill=fill, unique=unique
         )
     )  # type: np.ndarray
+
+    x.flags.writeable = not read_only
+
     constant = draw(constant) if isinstance(constant, st.SearchStrategy) else constant
 
     tensor = VerboseTensor(x, constant=constant, _copy_data=False)

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -154,6 +154,10 @@ def tensors(
         Defaults to (-10, 10)
         Specifying ``grad_element_bounds``, while ``include_grad`` is False, will raise an error.
 
+    Returns
+    -------
+    st.SearchStrategy[Tensor]
+
     Tensors of specified ``dtype`` and ``shape`` are generated for example
     like this:
 
@@ -205,7 +209,7 @@ def tensors(
     )  # type: np.ndarray
     constant = draw(constant) if isinstance(constant, st.SearchStrategy) else constant
 
-    tensor = VerboseTensor(x, constant=constant)
+    tensor = VerboseTensor(x, constant=constant, _copy_data=False)
     if isinstance(include_grad, st.SearchStrategy):
         include_grad = draw(include_grad)
 

--- a/tests/custom_strategies/test_strategies.py
+++ b/tests/custom_strategies/test_strategies.py
@@ -277,3 +277,15 @@ def test_tensors_with_grad(
 def test_tensor_owns_memory(t: Tensor):
     assert t.base is None
     assert t.data.base is None
+
+
+@given(tensor=tensors())
+def test_tensor_read_only_default(tensor: Tensor):
+    assert tensor.data.flags.writeable is True
+
+
+@pytest.mark.parametrize("read_only", [True, False])
+@given(data=st.data())
+def test_tensor_read_only(data: st.DataObject, read_only: bool):
+    tensor = data.draw(tensors(read_only=read_only))
+    assert tensor.data.flags.writeable is not read_only

--- a/tests/linalg/test_multi_matmul.py
+++ b/tests/linalg/test_multi_matmul.py
@@ -52,6 +52,7 @@ def test_matmul_fwd(signature):
         default_bnds=(-10, 10),
         atol=1e-5,
         rtol=1e-5,
+        internal_view_is_ok=True,
     )
     def test_runner():
         pass

--- a/tests/nnet/layers/test_batchnorm.py
+++ b/tests/nnet/layers/test_batchnorm.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 import mygrad as mg
 from mygrad import Tensor
 from mygrad.nnet.layers.batchnorm import batchnorm
+from tests import as_numpy
 from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
@@ -138,7 +139,7 @@ def test_batchnorm(x, data):
 
 
 def simple_batchnorm_numpy(x, gamma=None, beta=None, eps=0):
-    return mg.asarray(simple_batchnorm(x, eps=eps, gamma=gamma, beta=beta))
+    return as_numpy(simple_batchnorm(x, eps=eps, gamma=gamma, beta=beta))
 
 
 @settings(deadline=None)

--- a/tests/nnet/layers/test_conv.py
+++ b/tests/nnet/layers/test_conv.py
@@ -1,5 +1,4 @@
 """ Test conv fwd-prop and back-prop for ND convs"""
-
 from typing import Tuple
 
 import hypothesis.extra.numpy as hnp
@@ -13,6 +12,7 @@ from pytest import raises
 import mygrad as mg
 from mygrad import Tensor
 from mygrad.nnet.layers import conv_nd
+from tests import as_numpy
 
 from ...utils.numerical_gradient import numerical_gradient_full
 from ...wrappers.uber import backprop_test_factory, fwdprop_test_factory
@@ -291,15 +291,15 @@ def test_conv_1d_fwd():
     behavior with `constant` arg, etc."""
 
 
-def _conv_nd(x, w, stride, dilation=1, padding=0):
+def _conv_nd(x, w, stride, dilation=1, padding=0) -> np.ndarray:
     """ use mygrad-conv_nd forward pass for numerical derivative
 
-        Returns
-        -------
-        numpy.ndarray"""
-    return conv_nd(
-        x, w, stride=stride, dilation=dilation, padding=padding, constant=True
-    ).data
+    Returns
+    -------
+    numpy.ndarray"""
+    return as_numpy(
+        conv_nd(x, w, stride=stride, dilation=dilation, padding=padding, constant=True)
+    )
 
 
 @settings(deadline=None)

--- a/tests/nnet/losses/test_focal_loss.py
+++ b/tests/nnet/losses/test_focal_loss.py
@@ -7,6 +7,7 @@ from hypothesis import given
 import mygrad as mg
 from mygrad.nnet.activations import softmax
 from mygrad.nnet.losses import focal_loss, softmax_focal_loss
+from tests import as_numpy
 from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
@@ -23,7 +24,7 @@ def numpy_softmax_focal_loss(
     scores: np.ndarray, targets: np.ndarray, alpha: float, gamma: float
 ) -> np.ndarray:
     targets = mg.asarray(targets)
-    scores = softmax(scores).data
+    scores = as_numpy(softmax(scores))
     rows = np.arange(len(scores))
     pc = scores[rows, targets]
     return -alpha * np.clip(1 - pc, a_min=0, a_max=1) ** gamma * np.log(pc)

--- a/tests/state_testing/simple_graph.py
+++ b/tests/state_testing/simple_graph.py
@@ -50,11 +50,11 @@ class Node:
         f = Op()
         op_out = f(*tensor_vars)
         is_const = constant or all(var.constant for var in tensor_vars)
-        if not is_const:
-            # record that a variable participated in that op
-            for var in tensor_vars:
-                if not var.constant:
-                    var._ops.append(f)
+
+        # record that a variable participated in that op
+        for var in tensor_vars:
+            var._ops.append(f)
+
         return cls(op_out, constant=is_const, _creator=f)
 
     def backward(self, grad=None, terminal_node=False):

--- a/tests/state_testing/test_state.py
+++ b/tests/state_testing/test_state.py
@@ -99,6 +99,9 @@ class GraphCompare(RuleBasedStateMachine):
             self.raised = True
         else:
             t.backward(grad)
+            assert not t._accum_ops
+            assert not t._ops
+            assert not t.creator
 
     @precondition(lambda self: not self.raised)
     @invariant()

--- a/tests/tensor_base/test_chainrule.py
+++ b/tests/tensor_base/test_chainrule.py
@@ -22,7 +22,7 @@ def _check_grad(t: mg.Tensor, expr: Union[None, np.ndarray, float]):
 
 
 def _check_cleared_node(t: mg.Tensor):
-    assert not t._ops and t.creator is None
+    assert not t._ops and not t._accum_ops and t.creator is None
 
 
 def test_check_grad():

--- a/tests/tensor_base/test_memory_locking.py
+++ b/tests/tensor_base/test_memory_locking.py
@@ -1,10 +1,22 @@
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 from hypothesis import given
 
 from mygrad import Tensor
 from tests.custom_strategies import tensors
 from tests.utils import flags_to_dict
+
+
+def test_memory_locks_during_graph():
+    x = Tensor([1.0, 2.0])
+    assert x.data.flags.writeable
+
+    y = +x  # should lock memory
+    with pytest.raises(ValueError):
+        x.data *= 1
+    y.backward()  # should release memory
+    x.data *= 1
 
 
 @given(tensor=tensors(shape=(2,), read_only=st.booleans(), constant=False),)

--- a/tests/tensor_base/test_memory_locking.py
+++ b/tests/tensor_base/test_memory_locking.py
@@ -1,0 +1,75 @@
+import hypothesis.strategies as st
+import numpy as np
+from hypothesis import given
+
+from mygrad import Tensor
+from tests.custom_strategies import tensors
+from tests.utils import flags_to_dict
+
+
+@given(tensor=tensors(shape=(2,), read_only=st.booleans(), constant=False),)
+def test_lock_restore_writeability_roundtrip(tensor: Tensor,):
+    original_flags = flags_to_dict(tensor)
+
+    tensor._lock_writeability()
+
+    assert not tensor.data.flags.writeable
+
+    tensor._restore_writeability()
+
+    restored_flags = flags_to_dict(tensor)
+
+    assert tensor._data_was_writeable is None
+    assert tensor._base_data_was_writeable is None
+    assert original_flags == restored_flags
+
+
+@given(read_only=st.booleans())
+def test_lock_restore_writeability_with_base_roundtrip(read_only: bool):
+    base_arr = np.array([1.0, 2.0])
+    base_arr.flags.writeable = not read_only
+    view = base_arr[...]
+
+    original_flags = flags_to_dict(base_arr)
+    view_flags = flags_to_dict(view)
+
+    tensor = Tensor(view, _copy_data=False)
+
+    tensor._lock_writeability()
+
+    assert not base_arr.flags.writeable
+    assert not view.flags.writeable
+
+    tensor._restore_writeability()
+
+    restored_flags = flags_to_dict(base_arr)
+    restored_view_flags = flags_to_dict(view)
+
+    assert tensor._data_was_writeable is None
+    assert tensor._base_data_was_writeable is None
+    assert original_flags == restored_flags
+    assert view_flags == restored_view_flags
+
+
+@given(tensor=tensors(shape=(2,), read_only=st.booleans(), constant=False),)
+def test_lock_restore_writeability_roundtrip_of_view(tensor: Tensor):
+    original_flags = flags_to_dict(tensor)
+
+    view = tensor[...]
+
+    view._lock_writeability()
+
+    assert not tensor.data.flags.writeable
+    assert not view.data.flags.writeable
+
+    view._restore_writeability()
+
+    restored_flags = flags_to_dict(tensor)
+
+    assert tensor._data_was_writeable is None
+    assert tensor._base_data_was_writeable is None
+    assert original_flags == restored_flags
+
+    assert view._data_was_writeable is None
+    assert view._base_data_was_writeable is None
+    assert view.data.flags.writeable is original_flags["WRITEABLE"]

--- a/tests/tensor_base/test_op_wrapper.py
+++ b/tests/tensor_base/test_op_wrapper.py
@@ -17,19 +17,17 @@ def dummy(a, b, constant=False):
     return Tensor._op(Dummy, a, b, constant=constant)
 
 
-def test_constant_arg():
+@pytest.mark.parametrize("x_const", [True, False])
+@pytest.mark.parametrize("y_const", [True, False])
+@pytest.mark.parametrize("op_const", [True, False])
+def test_constant_arg(x_const: bool, y_const: bool, op_const: bool):
     """ test that the `constant` arg works as intended in Tensor._op"""
-    a = Tensor(1)
-    b = Tensor(1)
-    o_true = dummy(a, b, constant=True)
-    assert o_true.constant is True
-    assert a._ops == set()
-    assert b._ops == set()
-
-    o_false = dummy(a, b, constant=False)
-    assert o_false.constant is False
-    assert a._ops == {o_false.creator}
-    assert b._ops == {o_false.creator}
+    x = Tensor(1, constant=x_const)
+    y = Tensor(1, constant=y_const)
+    out = dummy(x, y, constant=op_const)
+    assert out.constant is op_const or (x_const and y_const)
+    assert x._ops == {out.creator}
+    assert y._ops == {out.creator}
 
 
 @pytest.mark.parametrize("x_const", [True, False])

--- a/tests/tensor_base/test_op_wrapper.py
+++ b/tests/tensor_base/test_op_wrapper.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 from mygrad.operation_base import Operation
 from mygrad.tensor_base import Tensor
 
@@ -5,7 +8,9 @@ from mygrad.tensor_base import Tensor
 class Dummy(Operation):
     def __call__(self, a, b):
         self.variables = (a, b)
-        return 1
+        # stores output array to check memory consistency
+        self.array_out = a.data * b.data
+        return self.array_out
 
 
 def dummy(a, b, constant=False):
@@ -25,3 +30,15 @@ def test_constant_arg():
     assert o_false.constant is False
     assert a._ops == {o_false.creator}
     assert b._ops == {o_false.creator}
+
+
+@pytest.mark.parametrize("x_const", [True, False])
+@pytest.mark.parametrize("y_const", [True, False])
+@pytest.mark.parametrize("op_const", [True, False])
+def test_op_wrapper_doesnt_make_copy_when_creating_output_tensor(
+    x_const: bool, y_const: bool, op_const: bool
+):
+    x = Tensor([1.0], constant=x_const)
+    y = Tensor([2.0], constant=y_const)
+    out_tensor = dummy(x, y, constant=op_const)
+    assert np.shares_memory(out_tensor, out_tensor.creator.array_out)

--- a/tests/tensor_base/test_pow_special_cases.py
+++ b/tests/tensor_base/test_pow_special_cases.py
@@ -7,19 +7,26 @@ from hypothesis import given
 
 import mygrad as mg
 from mygrad.math.arithmetic.ops import Positive, Square
+from tests.custom_strategies import tensors
 
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
 def custom_pow(x, p, constant=False):
     out = x ** p
-    if isinstance(out, mg.Tensor):
+    if isinstance(out, mg.Tensor) and constant:
         out._constant = constant
     return out
 
 
 def any_scalar(*args, p):
     return st.sampled_from([int(p), float(p), np.array(p)])
+
+
+@given(x=tensors(), p=st.sampled_from([2, 3]))
+def test_special_pow_propagate_constant(x, p):
+    y = x ** p
+    assert y.constant is x.constant
 
 
 @pytest.mark.parametrize("power, op", [(1, Positive), (2, Square)])

--- a/tests/tensor_base/test_shares_memory.py
+++ b/tests/tensor_base/test_shares_memory.py
@@ -56,3 +56,24 @@ def test_tensor_base_matches_ndarray_base():
 def test_views_of_non_arrays_leave_no_base():
     assert mg.reshape(2.0, (1,)).base is None
     assert mg.reshape(list(range(9)), (3, 3)).base is None
+
+
+def test_no_share_memory_view_is_still_view():
+    # an empty array can be a view without sharing memory
+    array = np.array([])
+    array_view = array[tuple()]
+    assert array_view.base is array, "expected numpy behavior does not hold"
+
+    array_view_of_view = array_view[tuple()]
+    assert (
+        array_view_of_view.base is not array_view
+    ), "expected numpy behavior does not hold"
+    assert array_view_of_view.base is array, "expected numpy behavior does not hold"
+
+    tensor = mg.Tensor([])
+    tensor_view = tensor[tuple()]
+    assert tensor_view.base is tensor
+
+    tensor_view_of_view = tensor_view[tuple()]
+    assert tensor_view_of_view.base is not tensor_view
+    assert tensor_view_of_view.base is tensor

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -3,7 +3,7 @@ import hypothesis.strategies as st
 import numpy as np
 import pytest
 from hypothesis import assume, given, settings
-from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+from numpy.testing import assert_array_equal, assert_equal
 from pytest import raises
 
 import mygrad as mg
@@ -179,15 +179,37 @@ def test_init_data():
         )
 
 
-@given(x=hnp.arrays(dtype=float, shape=hnp.array_shapes(min_dims=1, max_dims=4)))
-def test_init_data_rand(x):
+@given(
+    arr=hnp.arrays(
+        dtype=hnp.floating_dtypes(), shape=hnp.array_shapes(min_side=1, min_dims=1)
+    ),
+    as_tensor=st.booleans(),
+)
+def test_copy_on_init_behavior(arr: np.ndarray, as_tensor: bool):
+    x = Tensor(arr, _copy_data=False) if as_tensor else arr
+    t_no_constant = Tensor(x)
+    assert not np.shares_memory(t_no_constant, arr)
+
+    t_constant = Tensor(x, constant=True)
+    assert np.shares_memory(t_constant, arr)
+
+    t_not_constant = Tensor(x, constant=False)
+    assert not np.shares_memory(t_not_constant, arr)
+
+
+@given(
+    x=hnp.arrays(
+        dtype=hnp.floating_dtypes(), shape=hnp.array_shapes(min_side=0, min_dims=0)
+    )
+)
+def test_init_data_rand(x: np.ndarray):
     assert_equal(actual=Tensor(x).data, desired=x)
 
 
 @given(
     x=hnp.arrays(
         dtype=float,
-        shape=hnp.array_shapes(),
+        shape=hnp.array_shapes(min_dims=0, min_side=0),
         elements=st.floats(allow_infinity=False, allow_nan=False),
     )
     | st.floats(allow_infinity=False, allow_nan=False)

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -418,7 +418,7 @@ def test_axis_interchange_methods(op: str, constant: bool):
 
 @given(x=tensors(include_grad=st.booleans()), clear_graph=st.booleans())
 def test_null_gradients(x: Tensor, clear_graph: bool):
-    with pytest.deprecated_call():
+    with pytest.warns(FutureWarning):
         x.null_gradients(clear_graph=clear_graph)
 
 

--- a/tests/tensor_ops/test_getitem.py
+++ b/tests/tensor_ops/test_getitem.py
@@ -1,11 +1,16 @@
 import hypothesis.extra.numpy as hnp
 import numpy as np
-from hypothesis import settings
+from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
 from mygrad.tensor_base import Tensor
 
-from ..custom_strategies import adv_integer_index, arbitrary_indices, basic_indices
+from ..custom_strategies import (
+    adv_integer_index,
+    arbitrary_indices,
+    basic_indices,
+    tensors,
+)
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
@@ -26,9 +31,15 @@ def test_getitem():
     assert_allclose(x.grad, np.array([2, 3, 4]))
 
 
+@given(x=tensors())
+def test_get_item_propagate_constant(x: Tensor):
+    y = x[...]
+    assert y.constant is x.constant
+
+
 def get_item(arr, index, constant=False):
     o = arr[index]
-    if isinstance(o, Tensor):
+    if isinstance(o, Tensor) and constant:
         o._constant = constant
 
     return o

--- a/tests/tensor_ops/test_iter.py
+++ b/tests/tensor_ops/test_iter.py
@@ -20,8 +20,9 @@ def _sum(x, constant=False):
         if not isinstance(out, Tensor):
             # Hack to deal with summing over an empty tensor.
             # `sum(Tensor([]))` returns 0, which is fine
-            out = Tensor(out)
-        out._constant = constant
+            out = Tensor(out, constant=constant or x.constant)
+        if constant:
+            out._constant = constant
     else:
         out = np.asarray(out)  # ensure numpy-output is array
     return out

--- a/tests/tensor_ops/test_setitem.py
+++ b/tests/tensor_ops/test_setitem.py
@@ -243,15 +243,17 @@ def test_setitem_downstream_doesnt_affect_upstream_backprop():
     assert y.grad is None
 
 
-def test_setitem_doesnt_mutate_upstream_nodes():
+@pytest.mark.parametrize("x_constant", [True, False])
+@pytest.mark.parametrize("y_constant", [True, False])
+def test_setitem_doesnt_mutate_upstream_nodes(x_constant: bool, y_constant: bool):
     """ Ensure setitem doesn't mutate variable non-constant tensor"""
-    x = Tensor([1.0, 2.0])
-    y = Tensor([3.0, 4.0])
+    x = Tensor([1.0, 2.0], constant=x_constant)
+    y = Tensor([3.0, 4.0], constant=y_constant)
     z = x + y
     y[:] = 0
     y_old = z.creator.variables[-1]  # version of y that participated in x + y
-    assert_allclose(np.array([3.0, 4.0]), y_old.data)
-    assert_allclose(np.array([0.0, 0.0]), y.data)
+    assert_allclose(np.array([3.0, 4.0]), y_old)
+    assert_allclose(np.array([0.0, 0.0]), y)
 
 
 @settings(deadline=None, max_examples=1000)

--- a/tests/test_tensor_creation.py
+++ b/tests/test_tensor_creation.py
@@ -4,7 +4,7 @@ from typing import Union
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
-from hypothesis import given, assume
+from hypothesis import assume, given
 from numpy.testing import assert_array_equal
 
 from mygrad import Tensor, astensor
@@ -143,9 +143,6 @@ def test_astensor_returns_tensor_reference_consistently(t: Tensor, in_graph: boo
     if in_graph:
         t = +t
     assert astensor(t) is t
-    assert astensor(t).grad is t.grad
-    assert astensor(t).creator is t.creator
-
     assert astensor(t, dtype=t.dtype) is t
     assert astensor(t, constant=t.constant) is t
     assert astensor(t, dtype=t.dtype, constant=t.constant) is t
@@ -163,13 +160,13 @@ def test_astensor_with_incompat_constant_still_passes_array_ref(
 
     t2 = astensor(t, constant=not t.constant)
     assert t2 is not t
-    assert t2.data is t.data
+    assert (t2.data is t.data) is t2.constant  # data copied if constant=False
     assert t2.creator is None
 
-    t2 = astensor(t, dtype=t.dtype, constant=not t.constant)
-    assert t2 is not t
-    assert t2.data is t.data
-    assert t2.creator is None
+    t3 = astensor(t, dtype=t.dtype, constant=not t.constant)
+    assert t3 is not t
+    assert (t3.data is t.data) is t3.constant  # data copied if constant=False
+    assert t3.creator is None
 
 
 @given(

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,4 +1,9 @@
 from contextlib import contextmanager
+from typing import Dict, Union
+
+import numpy as np
+
+from mygrad import Tensor
 
 
 @contextmanager
@@ -15,3 +20,25 @@ def does_not_raise():
         ... x.lower()
     """
     yield
+
+
+array_flag_fields = (
+    "ALIGNED",
+    "BEHAVED",
+    "C_CONTIGUOUS",
+    "CARRAY",
+    "CONTIGUOUS",
+    "F_CONTIGUOUS",
+    "FARRAY",
+    "FNC",
+    "FORC",
+    "FORTRAN",
+    "OWNDATA",
+    "WRITEABLE",
+    "WRITEBACKIFCOPY",
+)
+
+
+def flags_to_dict(x: Union[Tensor, np.ndarray]) -> Dict[str, bool]:
+    arr = np.asarray(x)
+    return {k: arr.flags[k] for k in array_flag_fields}

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -6,6 +6,8 @@ import numpy as np
 from hypothesis import given
 from numpy.testing import assert_allclose
 
+from tests.custom_strategies import tensors
+from tests.utils import flags_to_dict
 from tests.utils.numerical_gradient import (
     finite_difference,
     numerical_gradient,
@@ -160,3 +162,10 @@ def test_numerical_gradient_vary_each(x, grad):
     (dx,) = numerical_gradient_full(lambda y: y[::-1], x, back_grad=np.array(grad))
     x_grad = grad[::-1]
     assert_allclose(actual=dx, desired=x_grad, atol=atol, rtol=rtol)
+
+
+@given(arr=tensors().map(np.asarray))
+def test_array_flags_to_dict(arr: np.ndarray):
+    x = flags_to_dict(arr)
+    for k, v in x.items():
+        assert arr.flags[k] is v

--- a/tests/wrappers/test_uber.py
+++ b/tests/wrappers/test_uber.py
@@ -1,11 +1,14 @@
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
 import mygrad as mg
+from mygrad import Tensor
+from mygrad.operation_base import Operation
 
-from .uber import backprop_test_factory
+from .uber import backprop_test_factory, fwdprop_test_factory
 
 
 class KWARG1:
@@ -75,3 +78,226 @@ def test_arr_from_kwargs(args_as_kwargs):
 
     if "kwarg1" in args_as_kwargs:
         assert KWARG1.passed
+
+
+def test_catches_bad_fwd_pass():
+    def mul2(x, constant=False):
+        return mg.multiply(x, 2, constant=constant)
+
+    def mul3(x):
+        return 3 * np.asarray(x)
+
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul3)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_output_not_tensor():
+    def mul2(x, constant=False):
+        return np.asarray(mg.multiply(x, 2, constant=constant))
+
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_bad_constant_propagation():
+    def mul2(x, constant=False):
+        return mg.multiply(x, 2, constant=False)
+
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_mutation_error():
+    class Mul2_Mutate(Operation):
+        def __call__(self, tensor):
+            self.variables = (tensor,)
+            tensor.data *= 2
+            return tensor.data * 2
+
+    def mul2_mutate(x, constant=False):
+        return Tensor._op(Mul2_Mutate, x, constant=constant)
+
+    def mul2(x):
+        return 2 * np.asarray(x)
+
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2_mutate, true_func=mul2)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_numpy_view_mygrad_copy():
+    def copy(x, constant):
+        return mg.reshape(x, x.shape, constant=constant).copy()
+
+    def view(x):
+        return np.reshape(x, x.shape)
+
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(
+        num_arrays=1, mygrad_func=copy, true_func=view, permit_0d_array_as_float=False,
+    )
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_numpy_copy_mygrad_view():
+    def copy(x, constant):
+        return mg.reshape(x, x.shape, constant=constant)
+
+    def view(x):
+        return np.reshape(x, x.shape).copy()
+
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(
+        num_arrays=1, mygrad_func=copy, true_func=view, permit_0d_array_as_float=False,
+    )
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_bad_constant_propagation():
+    def bad_const_prop(x, y, z, constant=False):
+        if not constant and any(not i.constant for i in [x, y, z]):
+            constant = True
+        return mg.multiply_sequence(x, y, z, constant=constant)
+
+    # fwd-uber had weird logic for
+    @settings(deadline=None, max_examples=5)
+    @fwdprop_test_factory(
+        num_arrays=3,
+        mygrad_func=bad_const_prop,
+        true_func=lambda x, y, z: x * y * z,
+        permit_0d_array_as_float=False,
+    )
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_incorrect_op_gradient():
+    class Mul2(Operation):
+        def __call__(self, tensor):
+            self.variables = (tensor,)
+            return tensor.data * 2
+
+        def backward_var(self, grad, index, **kwargs):
+            a = self.variables[index]
+            return grad * np.ones_like(a)  # should be: grad * 2 * np.ones_like(a)
+
+    def mul2(x, constant=False):
+        return Tensor._op(Mul2, x, constant=constant)
+
+    def mul2_numpy(x):
+        return 2 * np.asarray(x)
+
+    @settings(deadline=None, max_examples=5)
+    @backprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2_numpy)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_op_didnt_propagate_grad():
+    class Mul2(Operation):
+        def __call__(self, tensor):
+            self.variables = (tensor,)
+            return tensor.data * 2
+
+        def backward_var(self, grad, index, **kwargs):
+            a = self.variables[index]
+            return 2 * np.ones_like(a)  # should be: grad * 2 * np.ones_like(a)
+
+    def mul2(x, constant=False):
+        return Tensor._op(Mul2, x, constant=constant)
+
+    def mul2_numpy(x):
+        return 2 * np.asarray(x)
+
+    @settings(deadline=None, max_examples=5)
+    @backprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2_numpy)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_mutated_gradient():
+    class Mul2(Operation):
+        def __call__(self, tensor):
+            self.variables = (tensor,)
+            return tensor.data * 2
+
+        def backward_var(self, grad, index, **kwargs):
+            a = self.variables[index]
+            grad *= 2 * np.ones_like(a)
+            return grad
+
+    def mul2(x, constant=False):
+        return Tensor._op(Mul2, x, constant=constant)
+
+    def mul2_numpy(x):
+        return 2 * np.asarray(x)
+
+    @settings(deadline=None, max_examples=5)
+    @backprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2_numpy)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()
+
+
+def test_catches_backprop_mutated_input():
+    class Mul2(Operation):
+        def __call__(self, tensor):
+            self.variables = (tensor,)
+            return tensor.data * 2
+
+        def backward_var(self, grad, index, **kwargs):
+            a = self.variables[index]
+            a.data *= 3
+            return grad * 2 * np.ones_like(a)
+
+    def mul2(x, constant=False):
+        return Tensor._op(Mul2, x, constant=constant)
+
+    def mul2_numpy(x):
+        return 2 * np.asarray(x)
+
+    @settings(deadline=None, max_examples=5)
+    @backprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2_numpy)
+    def should_catch_error():
+        pass
+
+    with pytest.raises(AssertionError):
+        should_catch_error()

--- a/tests/wrappers/test_uber.py
+++ b/tests/wrappers/test_uber.py
@@ -61,7 +61,7 @@ def test_arr_from_kwargs(args_as_kwargs):
 
         return a * b * c
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         mygrad_func=sentinel,
         true_func=sentinel,
@@ -87,7 +87,7 @@ def test_catches_bad_fwd_pass():
     def mul3(x):
         return 3 * np.asarray(x)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul3)
     def should_catch_error():
         pass
@@ -100,7 +100,7 @@ def test_catches_output_not_tensor():
     def mul2(x, constant=False):
         return np.asarray(mg.multiply(x, 2, constant=constant))
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2)
     def should_catch_error():
         pass
@@ -113,7 +113,7 @@ def test_catches_bad_constant_propagation():
     def mul2(x, constant=False):
         return mg.multiply(x, 2, constant=False)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2, true_func=mul2)
     def should_catch_error():
         pass
@@ -137,7 +137,7 @@ def test_catches_mutation_error():
     def mul2(x):
         return 2 * np.asarray(x)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(num_arrays=1, mygrad_func=mul2_mutate, true_func=mul2)
     def should_catch_error():
         pass
@@ -153,7 +153,7 @@ def test_catches_numpy_view_mygrad_copy():
     def view(x):
         return np.reshape(x, x.shape)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(
         num_arrays=1, mygrad_func=copy, true_func=view, permit_0d_array_as_float=False,
     )
@@ -171,7 +171,7 @@ def test_catches_numpy_copy_mygrad_view():
     def view(x):
         return np.reshape(x, x.shape).copy()
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(
         num_arrays=1, mygrad_func=copy, true_func=view, permit_0d_array_as_float=False,
     )
@@ -188,7 +188,7 @@ def test_bad_constant_propagation():
             constant = True
         return mg.multiply_sequence(x, y, z, constant=constant)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @fwdprop_test_factory(
         num_arrays=3,
         mygrad_func=bad_const_prop,
@@ -215,7 +215,7 @@ def test_catches_incorrect_op_gradient():
     def mul2_wrong_grad(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=1, mygrad_func=mul2_wrong_grad, true_func=lambda x: 2 * x
     )
@@ -239,7 +239,7 @@ def test_catches_op_didnt_propagate_grad():
     def mul2_doesnt_prop_incoming_grad(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=1,
         mygrad_func=mul2_doesnt_prop_incoming_grad,
@@ -266,7 +266,7 @@ def test_catches_mutated_gradient():
     def mul2_backprop_mutates_grad(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=1, mygrad_func=mul2_backprop_mutates_grad, true_func=lambda x: 2 * x
     )
@@ -293,7 +293,7 @@ def test_catches_backprop_mutated_input():
     def mul2_backprop_mutates_input(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=1, mygrad_func=mul2_backprop_mutates_input, true_func=lambda x: 2 * x
     )
@@ -310,7 +310,7 @@ def tests_catches_input_tensors_memory_not_locked_by_op():
         x._restore_writeability()
         return out
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=2, mygrad_func=mul_releases_input_lock, true_func=lambda x, y: x * y
     )
@@ -327,7 +327,7 @@ def tests_catches_output_tensors_memory_not_locked_by_op():
         out._restore_writeability()
         return out
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=2, mygrad_func=mul_releases_output_lock, true_func=lambda x, y: x * y
     )
@@ -344,7 +344,7 @@ def tests_catches_tensors_memory_writeability_not_restored_after_clear_graph():
         x._data_was_writeable = None
         return out
 
-    @settings(deadline=None, max_examples=5)
+    @settings(deadline=None, max_examples=20)
     @backprop_test_factory(
         num_arrays=2,
         mygrad_func=mul_deletes_writeability_history_lock,

--- a/tests/wrappers/uber.py
+++ b/tests/wrappers/uber.py
@@ -320,9 +320,9 @@ class fwdprop_test_factory:
             assert isinstance(
                 output_tensor, Tensor
             ), f"`mygrad_func` returned type {type(output_tensor)}, should return `mygrad.Tensor`"
-            assert output_tensor.constant is constant or bool(sum(tensor_constants)), (
+            assert output_tensor.constant is (constant or all(tensor_constants)), (
                 f"`mygrad_func` returned tensor.constant={output_tensor.constant}, "
-                f"should be constant={constant or  bool(sum(tensor_constants))}"
+                f"should be constant={constant or all(tensor_constants)}"
             )
 
             output_array = self.true_func(*arrs, **kwargs)

--- a/tests/wrappers/uber.py
+++ b/tests/wrappers/uber.py
@@ -347,7 +347,9 @@ class fwdprop_test_factory:
                 else:
                     assert output_tensor.base is None
 
-            if not all(arr.base is None for arr in arrs):
+            if not all(
+                not isinstance(arr, np.ndarray) or arr.base is None for arr in arrs
+            ):
                 raise ValueError(
                     "PROBLEM WITH TEST: The arrays drawn for the uber test do not own their "
                     "own memory. They must own their own memory in order for view-validation "

--- a/tests/wrappers/uber.py
+++ b/tests/wrappers/uber.py
@@ -347,10 +347,17 @@ class fwdprop_test_factory:
                 else:
                     assert output_tensor.base is None
 
+            if not all(arr.base is None for arr in arrs):
+                raise ValueError(
+                    "PROBLEM WITH TEST: The arrays drawn for the uber test do not own their "
+                    "own memory. They must own their own memory in order for view-validation "
+                    "to be valid"
+                )
+
             # check that tensor/array views are consistent
             for input_ind, (tens, arr) in enumerate(zip(mygrad_inputs, arrs)):
-                arr_share = np.shares_memory(output_array, arr)
-                tens_share = np.shares_memory(output_tensor, tens)
+                arr_share = output_array.base is arr
+                tens_share = output_tensor.base is tens
                 assert arr_share is tens_share, f"input-{input_ind}"
 
                 if tens_share:

--- a/tests/wrappers/uber.py
+++ b/tests/wrappers/uber.py
@@ -311,7 +311,7 @@ class fwdprop_test_factory:
                 Tensor(i, constant=c) if isinstance(i, np.ndarray) else i
                 for i, c in zip(arrs, tensor_constants)
             )
-            output_tensor = self.op(*mygrad_inputs, **kwargs, constant=constant,)
+            output_tensor = self.op(*mygrad_inputs, **kwargs, constant=constant)
 
             note(f"arrs: {arrs}")
             note(f"mygrad output: {output_tensor}")


### PR DESCRIPTION
- `Tensor(x, constant=False)` now copies data
- Tensors that participate in ops have their memory locked - clearing the graph restores memory writeability status
