### PR TITLE
Add no graph mode

### DIFF
--- a/src/mygrad/__init__.py
+++ b/src/mygrad/__init__.py
@@ -1,5 +1,9 @@
-from mygrad.tensor_base import Tensor, asarray, astensor  # isort:skip  # avoid an import cycle
-
+from mygrad.tensor_base import (  # isort:skip  # avoid an import cycle
+    Tensor,
+    asarray,
+    astensor,
+)
+from mygrad._graph_tracking import no_autodiff
 from mygrad.indexing_routines.funcs import *
 from mygrad.linalg.funcs import *
 from mygrad.math.arithmetic.funcs import *

--- a/src/mygrad/_graph_tracking.py
+++ b/src/mygrad/_graph_tracking.py
@@ -1,9 +1,10 @@
 """
 Provides user interface for suspending computational graph tracking and back-propagation
 """
-
 from functools import wraps
 from typing import Callable
+
+import numpy as np
 
 __all__ = ["no_autodiff"]
 
@@ -26,14 +27,24 @@ class NoAutoDiff:
         global TRACK_GRAPH
         TRACK_GRAPH = True
 
-    def __call__(self, func: Callable) -> Callable:
-        """A decorated function will have graph-tracking suspended
-        during its execution."""
+    def __call__(self, func: Callable, to_numpy: bool = False) -> Callable:
+        """Decorates a function so that it will have graph-tracking suspended
+        during its execution.
+
+        Parameters
+        ----------
+        func : Callable
+            The function to be decorated
+
+        to_numpy : bool, optional (default=False)
+            If true, the output is assumed to be array-like and
+            will be cast to a numpy array"""
 
         @wraps(func)
         def wrapper(*args, **kwargs):
             with self:
-                return func(*args, **kwargs)
+                out = func(*args, **kwargs)
+            return out if not to_numpy else np.asarray(out)
 
         return wrapper
 

--- a/src/mygrad/_graph_tracking.py
+++ b/src/mygrad/_graph_tracking.py
@@ -13,19 +13,24 @@ __all__ = ["no_autodiff"]
 TRACK_GRAPH = True  # type: bool
 
 
-class NoAutoDiff:
+class _NoAutoDiff:
     """ Serves as a context manager and decorator for suspending
     all computational graph tracking."""
+
+    depth = 0
 
     def __enter__(self):
         """Suspends graph-tracking"""
         global TRACK_GRAPH
+        self.depth += 1
         TRACK_GRAPH = False
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Restores graph-tracking"""
         global TRACK_GRAPH
-        TRACK_GRAPH = True
+        self.depth -= 1
+
+        TRACK_GRAPH = self.depth == 0
 
     def __call__(self, func: Callable, to_numpy: bool = False) -> Callable:
         """Decorates a function so that it will have graph-tracking suspended
@@ -49,4 +54,4 @@ class NoAutoDiff:
         return wrapper
 
 
-no_autodiff = NoAutoDiff()
+no_autodiff = _NoAutoDiff()

--- a/src/mygrad/_graph_tracking.py
+++ b/src/mygrad/_graph_tracking.py
@@ -1,0 +1,41 @@
+"""
+Provides user interface for suspending computational graph tracking and back-propagation
+"""
+
+from functools import wraps
+from typing import Callable
+
+__all__ = ["no_autodiff"]
+
+
+# If `False`, suspends all computational graph tracking and backprop
+TRACK_GRAPH = True  # type: bool
+
+
+class NoAutoDiff:
+    """ Serves as a context manager and decorator for suspending
+    all computational graph tracking."""
+
+    def __enter__(self):
+        """Suspends graph-tracking"""
+        global TRACK_GRAPH
+        TRACK_GRAPH = False
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Restores graph-tracking"""
+        global TRACK_GRAPH
+        TRACK_GRAPH = True
+
+    def __call__(self, func: Callable) -> Callable:
+        """A decorated function will have graph-tracking suspended
+        during its execution."""
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with self:
+                return func(*args, **kwargs)
+
+        return wrapper
+
+
+no_autodiff = NoAutoDiff()

--- a/src/mygrad/_graph_tracking.py
+++ b/src/mygrad/_graph_tracking.py
@@ -17,20 +17,21 @@ class _NoAutoDiff:
     """ Serves as a context manager and decorator for suspending
     all computational graph tracking."""
 
-    depth = 0
+    # tracks context depth
+    _depth = 0  # type: int
 
     def __enter__(self):
         """Suspends graph-tracking"""
         global TRACK_GRAPH
-        self.depth += 1
+        self._depth += 1
         TRACK_GRAPH = False
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """Restores graph-tracking"""
+        """Restores graph-tracking when context depth returns to 0"""
         global TRACK_GRAPH
-        self.depth -= 1
+        self._depth -= 1
 
-        TRACK_GRAPH = self.depth == 0
+        TRACK_GRAPH = self._depth == 0
 
     def __call__(self, func: Callable, to_numpy: bool = False) -> Callable:
         """Decorates a function so that it will have graph-tracking suspended
@@ -43,7 +44,11 @@ class _NoAutoDiff:
 
         to_numpy : bool, optional (default=False)
             If true, the output is assumed to be array-like and
-            will be cast to a numpy array"""
+            will be cast to a numpy array
+
+        Returns
+        -------
+        decorated_func : Callable"""
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/src/mygrad/math/sequential/ops.py
+++ b/src/mygrad/math/sequential/ops.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import numpy as np
 
+import mygrad._graph_tracking as _tracking
 from mygrad.operation_base import Operation
 
 __all__ = ["MaxMin", "Sum", "Mean", "Prod", "CumProd", "CumSum", "Variance", "StdDev"]
@@ -34,8 +35,14 @@ class MaxMin(Operation):
             amax : ndarray
                 Maximum (minimum) of `a`. If `axis` is None, the result is a 0-D array."""
         assert maxmin in ("max", "min"), "Invalid keyword argument"
+
+        if not _tracking.TRACK_GRAPH:
+            op = np.max if maxmin == "max" else np.min
+            return op(np.asarray(a), axis=axis, keepdims=keepdims)
+
         op = np.argmax if maxmin == "max" else np.argmin
 
+        # TODO: optimize this
         # let numpy handle error checking
         np.amax(np.empty([1] * a.ndim), axis=axis, keepdims=keepdims)
 

--- a/src/mygrad/nnet/activations/softmax.py
+++ b/src/mygrad/nnet/activations/softmax.py
@@ -25,12 +25,12 @@ class Softmax(Operation):
         x = a.data
 
         self._kw = dict(axis=axis, keepdims=True)
-
-        return _softmax(x, self._kw)
+        self._cached_output = _softmax(x, self._kw)
+        return self._cached_output
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
-        soft = _softmax(a.data, self._kw)
+        _ = self.variables[index]  # check index error
+        soft = self._cached_output
         sg = soft * grad
         return sg - soft * np.sum(sg, **self._kw)
 

--- a/src/mygrad/nnet/losses/focal_loss.py
+++ b/src/mygrad/nnet/losses/focal_loss.py
@@ -2,6 +2,7 @@ from numbers import Real
 
 import numpy as np
 
+import mygrad._graph_tracking as _tracking
 from mygrad.nnet.activations import softmax
 from mygrad.operation_base import Operation
 from mygrad.tensor_base import Tensor, asarray
@@ -68,6 +69,9 @@ class FocalLoss(Operation):
 
         one_m_pc_gamma = one_m_pc ** gamma
         loss = -(alpha * one_m_pc_gamma * log_pc)
+
+        if not _tracking.TRACK_GRAPH:
+            return loss
 
         self.back = np.zeros(class_probs.shape, dtype=np.float64)
 

--- a/src/mygrad/nnet/losses/margin_ranking_loss.py
+++ b/src/mygrad/nnet/losses/margin_ranking_loss.py
@@ -2,6 +2,7 @@ from numbers import Real
 
 import numpy as np
 
+import mygrad._graph_tracking as _tracking
 from mygrad.operation_base import Operation
 from mygrad.tensor_base import Tensor, asarray
 
@@ -35,10 +36,10 @@ class MarginRanking(Operation):
         not_thresh = M <= 0
         loss = M
         loss[not_thresh] = 0.0
-
-        self._grad = np.ones_like(M)
-        self._grad[not_thresh] = 0.0
-        self._grad /= M.size
+        if _tracking.TRACK_GRAPH:
+            self._grad = np.ones_like(M)
+            self._grad[not_thresh] = 0.0
+            self._grad /= M.size
         return np.mean(loss)
 
     def backward_var(self, grad, index, **kwargs):

--- a/src/mygrad/nnet/losses/multiclass_hinge.py
+++ b/src/mygrad/nnet/losses/multiclass_hinge.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import mygrad._graph_tracking as _tracking
 from mygrad.operation_base import Operation
 from mygrad.tensor_base import Tensor
 
@@ -42,13 +43,13 @@ class MulticlassHinge(Operation):
         Lij = M
         Lij[not_thresh] = 0
         Lij[correct_labels] = 0
-
-        TMP = np.ones(M.shape, dtype=float)
-        TMP[not_thresh] = 0
-        TMP[correct_labels] = 0  # NxC; 1 where margin > 0
-        TMP[correct_labels] = -1 * TMP.sum(axis=-1)
-        self.back = TMP
-        self.back /= scores.shape[0]
+        if _tracking.TRACK_GRAPH:
+            TMP = np.ones(M.shape, dtype=float)
+            TMP[not_thresh] = 0
+            TMP[correct_labels] = 0  # NxC; 1 where margin > 0
+            TMP[correct_labels] = -1 * TMP.sum(axis=-1)
+            self.back = TMP
+            self.back /= scores.shape[0]
         return np.sum(Lij) / scores.shape[0]
 
     def backward_var(self, grad, index, **kwargs):

--- a/src/mygrad/nnet/losses/softmax_crossentropy.py
+++ b/src/mygrad/nnet/losses/softmax_crossentropy.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+import mygrad._graph_tracking as _tracking
 from mygrad.math._special import logsumexp
 from mygrad.operation_base import Operation
 from mygrad.tensor_base import Tensor
@@ -36,9 +37,10 @@ class SoftmaxCrossEntropy(Operation):
         label_locs = (range(len(scores)), y_true)
         loss = -np.sum(log_softmax[label_locs]) / scores.shape[0]
 
-        self.back = np.exp(log_softmax)
-        self.back[label_locs] -= 1.0
-        self.back /= scores.shape[0]
+        if _tracking.TRACK_GRAPH:
+            self.back = np.exp(log_softmax)
+            self.back[label_locs] -= 1.0
+            self.back /= scores.shape[0]
         return loss
 
     def backward_var(self, grad, index, **kwargs):

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -119,8 +119,10 @@ class Operation:
             if not var.constant:
                 if not var._ops:
                     raise InvalidBackprop(
-                        "Part of the computational graph containing "
-                        "this tensor was 'cleared' prior to backprop."
+                        f"Part of the computational graph containing "
+                        f"this tensor, {var}, was 'cleared' prior to backprop.\n"
+                        f"It is recommended that you clear all computational graphs "
+                        f"and restart your computation."
                     )
 
                 try:

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -567,7 +567,7 @@ class Tensor:
             # information
             return cls(
                 op_out,
-                constant=True,
+                constant=constant,  # constant not determined by graph info
                 _creator=None,
                 _scalar_only=False,
                 _base=base,

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -519,20 +519,10 @@ class Tensor:
         mygrad.Tensor
             The tensor-result of the operation's forward-pass."""
 
-        if op_args is None:
-            op_args = tuple()
-
-        if op_kwargs is None:
-            op_kwargs = dict()
-
-        vars_can_share_mem = (
-            isinstance(var, (np.ndarray, Tensor)) for var in input_vars
-        )
-
-        f = Op()
-
+        # cast all input-vars to tensors
         if _track.TRACK_GRAPH:
-
+            # lock memory of array data and clear any tensor
+            # gradients
             tensor_vars = tuple(
                 (
                     cls(var, constant=True)
@@ -542,10 +532,20 @@ class Tensor:
                 for var in input_vars
             )
         else:
+            # operations are not being tracked - make all tensors
+            # constant
             tensor_vars = tuple(
                 cls(var, constant=True) if not isinstance(var, Tensor) else var
                 for var in input_vars
             )
+
+        if op_args is None:
+            op_args = tuple()
+
+        if op_kwargs is None:
+            op_kwargs = dict()
+
+        f = Op()
 
         op_out = f(*tensor_vars, *op_args, **op_kwargs)  # type: np.ndarray
 
@@ -553,18 +553,19 @@ class Tensor:
         if f.cannot_return_view:
             base = None
         else:
+            vars_can_share_mem = (
+                isinstance(var, (np.ndarray, Tensor)) for var in input_vars
+            )
             for can_share_mem, var in zip(vars_can_share_mem, tensor_vars):
                 if can_share_mem and _is_view_of(parent=var, child=op_out):
                     base = var if var.base is None else var.base
-                    assert not f.cannot_return_view, (
-                        f"{f} is marked as being unable to return a view, "
-                        f"however its output is a view of one of its inputs"
-                    )
                     break
             else:
                 base = None
 
         if not _track.TRACK_GRAPH:
+            # execute operation without tracking creator or any graph
+            # information
             return cls(
                 op_out,
                 constant=True,
@@ -596,9 +597,11 @@ class Tensor:
         for var in tensor_vars:
             var._ops.add(f)
 
-        scalar_only = f.scalar_only and not is_const
-        for var in tensor_vars:
-            scalar_only = scalar_only or (var.scalar_only and not var.constant)
+        # determine if node only supports backprop from a scalar
+        # terminus
+        scalar_only = (f.scalar_only and not is_const) or any(
+            var.scalar_only for var in tensor_vars if not var.constant
+        )
 
         return cls(
             op_out,

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -549,10 +549,11 @@ class Tensor:
 
         op_out = f(*tensor_vars, *op_args, **op_kwargs)  # type: np.ndarray
 
-        # determine whether or not op was a view
-        if f.cannot_return_view:
-            base = None
-        else:
+        # determine whether or not op was a view; if so, `base`
+        # points to parent Tensor
+        base = None  # type: Optional[Tensor]
+
+        if not f.cannot_return_view:
             vars_can_share_mem = (
                 isinstance(var, (np.ndarray, Tensor)) for var in input_vars
             )
@@ -560,8 +561,6 @@ class Tensor:
                 if can_share_mem and _is_view_of(parent=var, child=op_out):
                     base = var if var.base is None else var.base
                     break
-            else:
-                base = None
 
         if not _track.TRACK_GRAPH:
             # execute operation without tracking creator or any graph

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,0 @@
-from numpy import ndarray
-
-import mygrad as mg
-
-
-def as_numpy(x: mg.Tensor) -> ndarray:
-    """Utility for leveraging mygrad ops without incurring locked memory"""
-    x.clear_graph()
-    return mg.asarray(x)

--- a/tests/math/sequence/test_sequential_funcs.py
+++ b/tests/math/sequence/test_sequential_funcs.py
@@ -56,6 +56,19 @@ def test_max_fwd():
     pass
 
 
+@fwdprop_test_factory(
+    mygrad_func=amax,
+    true_func=mg.no_autodiff(mg.max, to_numpy=True),
+    num_arrays=1,
+    kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
+)
+def test_max_no_graph_track_fwd():
+    """tests no-graph mode transitively
+    mg.max == np.max
+    mg.max == mg.max(no-grad)"""
+    pass
+
+
 @backprop_test_factory(
     mygrad_func=amax,
     true_func=np.amax,
@@ -76,6 +89,19 @@ def test_max_bkwd():
     kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
 )
 def test_min_fwd():
+    pass
+
+
+@fwdprop_test_factory(
+    mygrad_func=amin,
+    true_func=mg.no_autodiff(mg.min, to_numpy=True),
+    num_arrays=1,
+    kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
+)
+def test_min_no_graph_track_fwd():
+    """tests no-graph mode transitively
+    mg.min == np.min
+    mg.min == mg.min(no-grad)"""
     pass
 
 

--- a/tests/nnet/layers/test_batchnorm.py
+++ b/tests/nnet/layers/test_batchnorm.py
@@ -7,7 +7,6 @@ from numpy.testing import assert_allclose, assert_array_equal
 import mygrad as mg
 from mygrad import Tensor
 from mygrad.nnet.layers.batchnorm import batchnorm
-from tests import as_numpy
 from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
@@ -138,8 +137,9 @@ def test_batchnorm(x, data):
         assert not b2._ops
 
 
+@mg.no_autodiff
 def simple_batchnorm_numpy(x, gamma=None, beta=None, eps=0):
-    return as_numpy(simple_batchnorm(x, eps=eps, gamma=gamma, beta=beta))
+    return mg.asarray(simple_batchnorm(x, eps=eps, gamma=gamma, beta=beta))
 
 
 @settings(deadline=None)

--- a/tests/nnet/layers/test_conv.py
+++ b/tests/nnet/layers/test_conv.py
@@ -12,7 +12,6 @@ from pytest import raises
 import mygrad as mg
 from mygrad import Tensor
 from mygrad.nnet.layers import conv_nd
-from tests import as_numpy
 
 from ...utils.numerical_gradient import numerical_gradient_full
 from ...wrappers.uber import backprop_test_factory, fwdprop_test_factory
@@ -291,13 +290,14 @@ def test_conv_1d_fwd():
     behavior with `constant` arg, etc."""
 
 
+@mg.no_autodiff
 def _conv_nd(x, w, stride, dilation=1, padding=0) -> np.ndarray:
     """ use mygrad-conv_nd forward pass for numerical derivative
 
     Returns
     -------
     numpy.ndarray"""
-    return as_numpy(
+    return mg.asarray(
         conv_nd(x, w, stride=stride, dilation=dilation, padding=padding, constant=True)
     )
 

--- a/tests/nnet/losses/test_focal_loss.py
+++ b/tests/nnet/losses/test_focal_loss.py
@@ -7,7 +7,6 @@ from hypothesis import given
 import mygrad as mg
 from mygrad.nnet.activations import softmax
 from mygrad.nnet.losses import focal_loss, softmax_focal_loss
-from tests import as_numpy
 from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
@@ -24,7 +23,7 @@ def numpy_softmax_focal_loss(
     scores: np.ndarray, targets: np.ndarray, alpha: float, gamma: float
 ) -> np.ndarray:
     targets = mg.asarray(targets)
-    scores = as_numpy(softmax(scores))
+    scores = mg.asarray(mg.no_autodiff(softmax)(scores))
     rows = np.arange(len(scores))
     pc = scores[rows, targets]
     return -alpha * np.clip(1 - pc, a_min=0, a_max=1) ** gamma * np.log(pc)

--- a/tests/nnet/losses/test_focal_loss.py
+++ b/tests/nnet/losses/test_focal_loss.py
@@ -79,6 +79,22 @@ def test_focal_fwd():
     pass
 
 
+@fwdprop_test_factory(
+    mygrad_func=focal_loss,
+    true_func=mg.no_autodiff(focal_loss),
+    index_to_arr_shapes={0: hnp.array_shapes(min_dims=2, max_dims=2)},
+    index_to_bnds={0: (1e-14, 100)},
+    num_arrays=1,
+    kwargs=dict(
+        targets=lambda scores: targets(scores=scores),
+        alpha=lambda scores: st.floats(-2, 2),
+        gamma=lambda scores: st.floats(0, 10),
+    ),
+)
+def test_focal_no_graph_fwd():
+    pass
+
+
 @backprop_test_factory(
     mygrad_func=focal_loss,
     true_func=numpy_focal_loss,

--- a/tests/tensor_base/test_no_null_grad_semantics.py
+++ b/tests/tensor_base/test_no_null_grad_semantics.py
@@ -29,7 +29,7 @@ def test_involving_a_tensor_in_a_graph_nulls_its_gradient(
     assert x._ops is not None
 
 
-@given(x=tensors(include_grad=st.booleans()))
+@given(x=tensors(elements=st.floats(-100, 100), include_grad=st.booleans()))
 def test_backprop_clears_graph(x: Tensor):
     for num_fwd_pass in range(2):
         note(f"Forward-pass iteration: {num_fwd_pass}")

--- a/tests/tensor_base/test_pow_special_cases.py
+++ b/tests/tensor_base/test_pow_special_cases.py
@@ -23,7 +23,7 @@ def any_scalar(*args, p):
     return st.sampled_from([int(p), float(p), np.array(p)])
 
 
-@given(x=tensors(), p=st.sampled_from([2, 3]))
+@given(x=tensors(elements=st.floats(-10, 10)), p=st.sampled_from([2, 3]))
 def test_special_pow_propagate_constant(x, p):
     y = x ** p
     assert y.constant is x.constant

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -154,6 +154,7 @@ def test_graph_tracking_through_multiple_context_depths(depth: int):
     def check_graph_tracking(func):
         def wrapper(*args, **kwargs):
             depth_tracker["cnt"] += 1
+            note(f"depth: {depth_tracker}")
             track_state = _tracking.TRACK_GRAPH
 
             out = no_autodiff(func)(*args, **kwargs)
@@ -170,7 +171,7 @@ def test_graph_tracking_through_multiple_context_depths(depth: int):
         assert _tracking.TRACK_GRAPH is False
         return +x
 
-    f = compose(check_graph_tracking for _ in range(depth))(func)
+    f = compose([check_graph_tracking] * depth + [func])
 
     assert _tracking.TRACK_GRAPH is True
     f(Tensor([1.0]))

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -3,7 +3,7 @@ import inspect
 import hypothesis.strategies as st
 import numpy as np
 import pytest
-from hypothesis import given
+from hypothesis import given, note
 from numpy.testing import assert_array_equal
 
 import mygrad._graph_tracking as _tracking
@@ -86,7 +86,7 @@ def test_no_autodiff_decorator(x: Tensor):
     assert y.constant
     assert y.creator is None
     assert not y._ops
-    assert x.data.flags.writeable
+    assert y.data.flags.writeable
 
     assert not x._ops
     assert x.data.flags.writeable
@@ -122,3 +122,53 @@ def test_to_numpy_returns_numpy_array(x: np.asarray):
     mygrad_max = no_autodiff(amax, to_numpy=True)(x, axis=-1)
     assert isinstance(mygrad_max, np.ndarray)
     assert_array_equal(numpy_max, mygrad_max)
+
+
+def test_nested_context():
+    assert _tracking.TRACK_GRAPH, "before all"
+
+    with no_autodiff:
+        assert not _tracking.TRACK_GRAPH, "level 1, pre-2"
+
+        with no_autodiff:
+            assert not _tracking.TRACK_GRAPH, "level 2"
+
+        assert not _tracking.TRACK_GRAPH, "level 1, post-2"
+
+    assert _tracking.TRACK_GRAPH, "post all"
+
+
+def compose(iter_of_funcs):
+    """(..., f, g, h) -> ... ∘ f ∘ g ∘ h"""
+    funcs = list(iter_of_funcs)
+    f = funcs.pop()
+    for g in funcs[::-1]:
+        f = g(f)
+    return f
+
+
+@given(depth=st.integers(1, 10))
+def test_graph_tracking_through_multiple_context_depths(depth: int):
+    depth_tracker = dict(cnt=0)
+
+    def check_graph_tracking(func):
+        @no_autodiff
+        def wrapper(*args, **kwargs):
+            depth_tracker["cnt"] += 1
+            assert (
+                _tracking.TRACK_GRAPH is False
+            ), f"(before) depth: {depth_tracker['cnt']}"
+            out = func(*args, **kwargs)
+            assert (
+                _tracking.TRACK_GRAPH is False
+            ), f"(after) depth: {depth_tracker['cnt']}"
+            return out
+
+        return wrapper
+
+    def func(x):
+        assert _tracking.TRACK_GRAPH is False
+        return +x
+
+    f = compose(check_graph_tracking for _ in range(depth))(func)
+    f(Tensor([1.0]))

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -6,7 +6,7 @@ from hypothesis import given
 from numpy.testing import assert_array_equal
 
 import mygrad._graph_tracking as _tracking
-from mygrad import Tensor, no_autodiff
+from mygrad import Tensor, amax, no_autodiff
 from tests.custom_strategies import tensors
 
 
@@ -94,3 +94,11 @@ def test_decorator_is_transparent_to_function_information():
     assert inspect.signature(undecorated) == inspect.signature(decorated)
     assert undecorated.__doc__ == decorated.__doc__
     assert undecorated.__name__ == decorated.__name__
+
+
+@given(tensors(shape=(3, 2, 4)).map(np.asarray))
+def test_to_numpy_returns_numpy_array(x: np.asarray):
+    numpy_max = np.max(x, axis=-1)
+    mygrad_max = no_autodiff(amax, to_numpy=True)(x, axis=-1)
+    assert isinstance(mygrad_max, np.ndarray)
+    assert_array_equal(numpy_max, mygrad_max)

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -19,16 +19,18 @@ def test_no_autodiff_context_manager(x: Tensor):
 
     with no_autodiff:
         y = +x
-        y.backward()
+
+        assert y.creator is None
+        assert y.data.flags.writeable
+
+        assert not x._ops
+        assert x.data.flags.writeable
+
+        y.backward()  # should be no-op
 
     assert y.constant
-    assert y.creator is None
     assert y.grad is None
-    assert y.data.flags.writeable
-
-    assert not x._ops
     assert x.grad is None
-    assert x.data.flags.writeable
 
     # check that standard behavior is restored
     y = 2 * x

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -1,0 +1,96 @@
+import inspect
+
+import numpy as np
+import pytest
+from hypothesis import given
+from numpy.testing import assert_array_equal
+
+import mygrad._graph_tracking as _tracking
+from mygrad import Tensor, no_autodiff
+from tests.custom_strategies import tensors
+
+
+def test_graph_tracking_is_on_by_default():
+    assert _tracking.TRACK_GRAPH is True
+
+
+@given(x=tensors(shape=(1,)))
+def test_no_autodiff_context_manager(x: Tensor):
+
+    with no_autodiff:
+        y = +x
+
+    assert y.constant
+    assert y.creator is None
+    assert not y._ops
+    assert x.data.flags.writeable
+
+    assert not x._ops
+    assert x.data.flags.writeable
+
+
+@given(old_x=tensors(shape=(2,), constant=False))
+def test_no_tracking_for_inplace_op(old_x: Tensor):
+    expected = old_x.copy()
+    expected[0] = -1
+
+    x = +old_x
+    y = 2 * x
+
+    with no_autodiff:
+        x[0] = -1
+
+    assert_array_equal(x, expected)
+
+    y.backward()
+    assert_array_equal(old_x.grad, np.full_like(old_x, 2.0))
+
+
+def test_no_autodiff_context_manager_restores_state():
+
+    with pytest.raises(ValueError):
+        with no_autodiff:
+            assert not _tracking.TRACK_GRAPH
+            raise ValueError()
+
+    assert _tracking.TRACK_GRAPH
+
+
+@given(x=tensors(shape=(1,)))
+def test_no_autodiff_decorator(x: Tensor):
+    @no_autodiff
+    def func(x):
+        return +x
+
+    y = func(x)
+    assert y.constant
+    assert y.creator is None
+    assert not y._ops
+    assert x.data.flags.writeable
+
+    assert not x._ops
+    assert x.data.flags.writeable
+
+
+def test_no_autodiff_decorator_restores_state():
+    @no_autodiff
+    def func():
+        assert not _tracking.TRACK_GRAPH
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        func()
+
+    assert _tracking.TRACK_GRAPH
+
+
+def test_decorator_is_transparent_to_function_information():
+    def undecorated(x, y, z=None, *, kwarg, **kwargs):
+        """a very special docstring"""
+        pass
+
+    decorated = no_autodiff(undecorated)
+
+    assert inspect.signature(undecorated) == inspect.signature(decorated)
+    assert undecorated.__doc__ == decorated.__doc__
+    assert undecorated.__name__ == decorated.__name__

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -1,5 +1,6 @@
 import inspect
 
+import hypothesis.strategies as st
 import numpy as np
 import pytest
 from hypothesis import given
@@ -14,7 +15,7 @@ def test_graph_tracking_is_on_by_default():
     assert _tracking.TRACK_GRAPH is True
 
 
-@given(x=tensors(shape=(1,)))
+@given(x=tensors(shape=(1,), elements=st.floats(-100, 100)))
 def test_no_autodiff_context_manager(x: Tensor):
 
     with no_autodiff:
@@ -48,7 +49,7 @@ def test_no_autodiff_context_manager(x: Tensor):
         assert_array_equal(x.grad, np.full_like(x, 2.0))
 
 
-@given(old_x=tensors(shape=(2,), constant=False))
+@given(old_x=tensors(shape=(2,), constant=False, elements=st.floats(-100, 100)))
 def test_no_tracking_for_inplace_op(old_x: Tensor):
     expected = old_x.copy()
     expected[0] = -1
@@ -115,7 +116,7 @@ def test_decorator_is_transparent_to_function_information():
     assert undecorated.__name__ == decorated.__name__
 
 
-@given(tensors(shape=(3, 2, 4)).map(np.asarray))
+@given(tensors(shape=(3, 2, 4), elements=st.floats(-100, 100)).map(np.asarray))
 def test_to_numpy_returns_numpy_array(x: np.asarray):
     numpy_max = np.max(x, axis=-1)
     mygrad_max = no_autodiff(amax, to_numpy=True)(x, axis=-1)


### PR DESCRIPTION
@aslvrstn @Zac-HD if you wouldn't mind taking a look at [`src/mygrad/_graph_tracking.py`](https://github.com/rsokl/MyGrad/blob/1253c23071d966165484678a1cff29b08ae4b35e/src/mygrad/_graph_tracking.py), I'd like to get your thoughts on if this implementation for a global flag is sensible, or if there are some details/precautions that I should heed

Adds `mygrad.no_autodiff`, which is a context manager and decorator that temporarily disables all of mygrad's graph-tracking and memory-locking logic.

```python
from mygrad import no_autodiff, arange

x = arange(10.)

with no_autodiff:
    y = 2 * x  # creates a constant tensor with no creator

# x._ops is empty - no operations were recorded
# x's memory is still writeable
```

```python
@no_autodiff
def forward_pass():
    # all mygrad operations in the function body will be performed
    # without any graph-tracking or memory locking
    pass
````

You can also effectively convert mygrad functions to their numpy counterparts now:

```python
import mygrad as mg
numpy_max = mg.no_autodiff(mg.max, to_numpy=True)
```