### PR TITLE
More mem lock tests

### DIFF
--- a/src/mygrad/_utils/lock_management.py
+++ b/src/mygrad/_utils/lock_management.py
@@ -130,6 +130,11 @@ def _release_lock_on_arr_writeability(arr: np.ndarray):
             # we no longer need to track the array
             arr.flags.writeable = True
             _array_tracker.pop(arr_id, None)
+            if not _array_tracker and _views_waiting_for_unlock:
+                # If no arrays are being tracked, then there can't
+                # be any views waiting to be unlocked.
+                # Clean up!
+                _views_waiting_for_unlock.clear()
     elif num_active_ops > 0:
         _array_counter[arr_id] = num_active_ops - 1
 

--- a/src/mygrad/_utils/lock_management.py
+++ b/src/mygrad/_utils/lock_management.py
@@ -2,8 +2,8 @@
 Provides utilities responsible for locking/releasing array writeability.
 """
 import os
-from collections import Counter
-from typing import TYPE_CHECKING, Dict, Generator, Iterable
+from collections import Counter, defaultdict
+from typing import TYPE_CHECKING, DefaultDict, Dict, Generator, Iterable
 from weakref import ref
 
 import numpy as np
@@ -11,6 +11,8 @@ import numpy as np
 from mygrad._utils import ContextTracker, WeakRefIterable
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import Set
+
     from mygrad import Tensor
     from mygrad._utils import WeakRef
 
@@ -22,7 +24,9 @@ _array_tracker = dict()  # type: Dict[int, WeakRef[Tensor]]
 
 # maps base-array ID to ID of view that can't be unlocked until
 # base is unlocked
-_views_waiting_for_unlock = dict()  # type: Dict[int, int] # base-id -> view-id
+_views_waiting_for_unlock = defaultdict(
+    set
+)  # type: DefaultDict[int, Set[int]] # base-id -> set of view-ids
 
 __all__ = [
     "lock_arr_writeability",
@@ -58,7 +62,11 @@ def lock_arr_writeability(arr: np.ndarray, force_lock: bool = False) -> np.ndarr
         The locked array"""
     arr_id = id(arr)
     if not array_is_tracked(arr):
-        if not force_lock and not arr.flags.writeable:
+        if (
+            not force_lock
+            and not arr.flags.writeable
+            and (arr.base is None or not array_is_tracked(arr.base))
+        ):
             # array is natively read-only; don't do anything
             return arr
         # keeps track of array so we can clean up the array
@@ -117,7 +125,7 @@ def _release_lock_on_arr_writeability(arr: np.ndarray):
             # Array is view and must wait until its base is released
             # before it can be unlocked
             # Thus we are still tracking this array
-            _views_waiting_for_unlock[id(arr.base)] = arr_id
+            _views_waiting_for_unlock[id(arr.base)].add(arr_id)
         else:
             # we no longer need to track the array
             arr.flags.writeable = True
@@ -137,21 +145,31 @@ def _release_lock_on_arr_writeability(arr: np.ndarray):
         #    or view is involved in new op
         #    or view can now get unlocked
         # under all conditions view will no longer be waiting to be unlocked
-        view_arr_id = _views_waiting_for_unlock.pop(arr_id)
+        for view_arr_id in tuple(_views_waiting_for_unlock[arr_id]):
 
-        if _array_counter[view_arr_id] > 0:
-            # view involved in new op
-            return
+            if _array_counter[view_arr_id] > 0:
+                # view involved in new op
+                continue
 
-        try:
-            view_arr = _array_tracker.pop(view_arr_id)()
-            if view_arr is None:
-                return
-        except KeyError:
-            # view array is no longer available for unlocking
-            return
+            _views_waiting_for_unlock[arr_id].remove(view_arr_id)
 
-        view_arr.flags.writeable = True
+            try:
+                view_arr = _array_tracker.pop(view_arr_id)()
+                if view_arr is None:
+                    continue
+            except KeyError:
+                # view array is no longer available for unlocking
+                continue
+
+            try:
+                view_arr.flags.writeable = True
+            except ValueError:  # pragma: no cover
+                # sometimes this raises.. but it is not
+                # reproducible and is very rare
+                pass
+
+        if not _views_waiting_for_unlock[arr_id]:
+            _views_waiting_for_unlock.pop(arr_id)
 
 
 def release_writeability_lock_on_op(arr_refs: WeakRefIterable[np.ndarray]):

--- a/src/mygrad/nnet/layers/batchnorm.py
+++ b/src/mygrad/nnet/layers/batchnorm.py
@@ -42,12 +42,13 @@ class BatchNorm(Operation):
         normed_dims = tuple(i for i in range(x.ndim) if i != 1)
         keepdims_shape = tuple(1 if n != 1 else d for n, d in enumerate(x.shape))
 
+        self.variables = tuple(i for i in (x, gamma, beta))
+
         if gamma.size == 0:
             gamma = None
         if beta.size == 0:
             beta = None
 
-        self.variables = tuple(i for i in (x, gamma, beta) if i is not None)
         self.gamma = gamma
         self.beta = beta
 
@@ -162,3 +163,9 @@ def batchnorm(x, *, gamma=None, beta=None, eps, constant=False):
     return Tensor._op(
         BatchNorm, x, gamma, beta, op_kwargs=dict(eps=eps), constant=constant
     )
+
+    # # pass gamma and beta as empty arrays if they are not supplied
+    # tvars = [t for t in (x, gamma, beta) if t is not None]
+    # return Tensor._op(
+    #     BatchNorm, *tvars, op_kwargs=dict(eps=eps), constant=constant
+    # )

--- a/src/mygrad/nnet/layers/batchnorm.py
+++ b/src/mygrad/nnet/layers/batchnorm.py
@@ -163,9 +163,3 @@ def batchnorm(x, *, gamma=None, beta=None, eps, constant=False):
     return Tensor._op(
         BatchNorm, x, gamma, beta, op_kwargs=dict(eps=eps), constant=constant
     )
-
-    # # pass gamma and beta as empty arrays if they are not supplied
-    # tvars = [t for t in (x, gamma, beta) if t is not None]
-    # return Tensor._op(
-    #     BatchNorm, *tvars, op_kwargs=dict(eps=eps), constant=constant
-    # )

--- a/src/mygrad/nnet/layers/gru.py
+++ b/src/mygrad/nnet/layers/gru.py
@@ -261,8 +261,8 @@ class GRUnit(Operation):
 
     def backward(self, grad, *, graph, **kwargs):
         hidden_seq = self._hidden_seq()
-        if hidden_seq is None:
-            assert False
+        if hidden_seq is None:  # pragma: no cover
+            assert False, "should be unreachable"
 
         s = hidden_seq.data[:-1]
         z = self._z.data

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -593,7 +593,7 @@ class Tensor:
             parent_var._view_children.append(out)
 
         if _mem.MEM_GUARD:
-            _mem.lock_arr_writeability(out.data, force_lock=True)
+            _mem.lock_arr_writeability(out.data)
             tensor_refs = _uniques_bases_then_arrs
             tensor_refs.append(out.data)
             finalize(f, _mem.release_writeability_lock_on_op, tensor_refs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ settings.register_profile("debug", max_examples=10, verbosity=Verbosity.verbose)
 settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def seal_memguard() -> bool:
     """Ensure test cannot mutate MEM_GUARD value"""
     initial_value = lock.MEM_GUARD
@@ -23,11 +23,12 @@ def seal_memguard() -> bool:
     yield initial_value
     if lock.MEM_GUARD is not initial_value:
         warnings.warn("test toggled MEM_GUARD value")
+        assert False
 
     lock.MEM_GUARD = initial_value
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def seal_graph_tracking() -> bool:
     """Ensure test cannot mutate TRACK_GRAPH value"""
     initial_value = track.TRACK_GRAPH
@@ -35,6 +36,7 @@ def seal_graph_tracking() -> bool:
 
     if track.TRACK_GRAPH is not initial_value:
         warnings.warn("test toggled TRACK_GRAPH value")
+        assert False
 
     track.TRACK_GRAPH = initial_value
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def seal_memguard() -> bool:
     yield initial_value
     if lock.MEM_GUARD is not initial_value:
         warnings.warn("test toggled MEM_GUARD value")
+        lock.MEM_GUARD = initial_value
         assert False
 
     lock.MEM_GUARD = initial_value
@@ -36,6 +37,7 @@ def seal_graph_tracking() -> bool:
 
     if track.TRACK_GRAPH is not initial_value:
         warnings.warn("test toggled TRACK_GRAPH value")
+        track.TRACK_GRAPH = initial_value
         assert False
 
     track.TRACK_GRAPH = initial_value

--- a/tests/nnet/layers/test_gru.py
+++ b/tests/nnet/layers/test_gru.py
@@ -7,7 +7,7 @@ import pytest
 from hypothesis import example, given, settings
 from numpy.testing import assert_allclose
 
-from mygrad import matmul, no_autodiff
+from mygrad import matmul, mem_guard_off, no_autodiff
 from mygrad.nnet.activations import sigmoid, tanh
 from mygrad.nnet.layers import gru
 from mygrad.tensor_base import Tensor
@@ -28,6 +28,7 @@ from tests.utils import does_not_raise
     dropout=st.floats(0, 1),
     out_constant=st.booleans(),
 )
+@mem_guard_off
 def test_nonconstant_s0_raises(s0, dropout: float, out_constant: bool):
     T, N, C, D = 5, 1, 3, 2
     X = Tensor(np.random.rand(T, N, C))
@@ -57,6 +58,7 @@ def test_nonconstant_s0_raises(s0, dropout: float, out_constant: bool):
 
 @settings(deadline=None)
 @given(out_constant=st.booleans())
+@mem_guard_off
 def test_all_constant(out_constant: bool):
     T, N, C, D = 5, 1, 3, 2
     X = Tensor(np.random.rand(T, N, C), constant=True)
@@ -95,6 +97,7 @@ def test_all_constant(out_constant: bool):
 )
 @pytest.mark.filterwarnings("ignore: overflow encountered in exp")
 @pytest.mark.filterwarnings("ignore: overflow encountered in sig")
+@mem_guard_off
 def test_gru_fwd(X, D, dropout, dtypes, data: st.DataObject):
     T, N, C = X.shape
 
@@ -245,6 +248,7 @@ def test_gru_fwd(X, D, dropout, dtypes, data: st.DataObject):
     assert_allclose(X.data, X2.data, **tolerances)
 
     ls.clear_graph()
+    ls2.clear_graph()
 
     for x in [s, Wz, Wr, Wh, bz, br, bh, X, Uz, Ur, Uh, V]:
         assert not x._ops
@@ -474,8 +478,8 @@ def test_gru_backward(
     else:
         assert X.grad is None
 
-    ls.clear_graph()
-    ls2.clear_graph()
+    # ls.clear_graph()
+    # ls2.clear_graph()
 
     for x in [s, Wz, Wr, Wh, bz, br, bh, X, Uz, Ur, Uh, V]:
         assert not x._ops

--- a/tests/nnet/layers/test_gru.py
+++ b/tests/nnet/layers/test_gru.py
@@ -478,8 +478,5 @@ def test_gru_backward(
     else:
         assert X.grad is None
 
-    # ls.clear_graph()
-    # ls2.clear_graph()
-
     for x in [s, Wz, Wr, Wh, bz, br, bh, X, Uz, Ur, Uh, V]:
         assert not x._ops

--- a/tests/state_testing/test_state.py
+++ b/tests/state_testing/test_state.py
@@ -18,6 +18,7 @@ from pytest import raises
 
 from mygrad import Tensor, add, multiply
 from mygrad.errors import InvalidBackprop
+from tests.utils import clear_all_mem_locking_state
 
 from .simple_graph import Node, _add, _multiply
 
@@ -123,6 +124,9 @@ class GraphCompare(RuleBasedStateMachine):
                     err_msg=_node_ID_str(num),
                 )
             assert not t._accum_ops, _node_ID_str(num)
+
+    def teardown(self):
+        clear_all_mem_locking_state()
 
 
 TestGraphComparison = GraphCompare.TestCase

--- a/tests/tensor_ops/test_reshape.py
+++ b/tests/tensor_ops/test_reshape.py
@@ -229,6 +229,12 @@ def test_input_validation(bad_input):
         x.reshape(*bad_input)
 
 
+# This test has really weird behavior
+# Something is preventing the except-clause
+# in Tensor._op to run
+# Turn mem-guard off to prevent the leak caused
+# by this
+@mg.mem_guard_off
 def test_input_validation_matches_numpy():
     try:
         np.reshape(np.array(1), *(1, 1))

--- a/tests/test_duplicating_graph.py
+++ b/tests/test_duplicating_graph.py
@@ -1,8 +1,6 @@
-import gc
 from typing import Callable, List, Tuple
 
 import hypothesis.strategies as st
-import pytest
 from hypothesis import given, settings
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, rule
 from numpy.testing import assert_array_equal
@@ -11,6 +9,7 @@ import mygrad as mg
 from mygrad import Tensor
 from mygrad._utils.duplicating_graph import DuplicatingGraph, Node
 from tests.custom_strategies import tensors
+from tests.utils import clear_all_mem_locking_state
 
 
 @given(x=tensors(read_only=st.booleans()))
@@ -203,6 +202,8 @@ class GraphDuplicationCompare(RuleBasedStateMachine):
                 assert (
                     t.creator.variables[0] is node.placeholder
                 ), "graph was not redirected consistently"
+
+        clear_all_mem_locking_state()  # don't leak state into other tests
 
 
 TestGraphComparison = GraphDuplicationCompare.TestCase

--- a/tests/test_in_place_semantics.py
+++ b/tests/test_in_place_semantics.py
@@ -148,6 +148,12 @@ def test_writing_a_view_with_a_view(
     assert dangling_view.base is y
     assert dangling_view.grad is None
 
+    dangling_view.clear_graph()  # release memory
+
+    assert x.data.flags.writeable
+    assert y.data.flags.writeable
+    assert dangling_view.data.flags.writeable
+
 
 def test_setitem_preserves_view_children():
     x = mg.arange(10.0)

--- a/tests/test_tensor_creation.py
+++ b/tests/test_tensor_creation.py
@@ -7,7 +7,7 @@ import numpy as np
 from hypothesis import assume, given
 from numpy.testing import assert_array_equal
 
-from mygrad import Tensor, astensor
+from mygrad import Tensor, astensor, mem_guard_off
 from mygrad.tensor_creation.funcs import (
     arange,
     empty,
@@ -175,6 +175,7 @@ def test_astensor_with_incompat_constant_still_passes_array_ref(
     dtype=st.none() | hnp.floating_dtypes(),
     constant=st.none() | st.booleans(),
 )
+@mem_guard_off
 def test_astensor_doesnt_mutate_input_tensor(
     t: Tensor, in_graph: bool, dtype, constant: bool
 ):

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Union
 
 import numpy as np
 
+import mygrad._utils.lock_management as mem
 from mygrad import Tensor
 
 
@@ -42,3 +43,9 @@ array_flag_fields = (
 def flags_to_dict(x: Union[Tensor, np.ndarray]) -> Dict[str, bool]:
     arr = np.asarray(x)
     return {k: arr.flags[k] for k in array_flag_fields}
+
+
+def clear_all_mem_locking_state():
+    mem._views_waiting_for_unlock.clear()
+    mem._array_tracker.clear()
+    mem._array_counter.clear()

--- a/tests/wrappers/test_uber.py
+++ b/tests/wrappers/test_uber.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_allclose
 import mygrad as mg
 from mygrad import Tensor
 from mygrad.operation_base import Operation
+from tests.utils import clear_all_mem_locking_state
 
 from .uber import backprop_test_factory, fwdprop_test_factory
 
@@ -80,6 +81,7 @@ def test_arr_from_kwargs(args_as_kwargs):
         assert KWARG1.passed
 
 
+@mg.mem_guard_off
 def test_catches_bad_fwd_pass():
     def mul2(x, constant=False):
         return mg.multiply(x, 2, constant=constant)
@@ -109,6 +111,7 @@ def test_catches_output_not_tensor():
         should_catch_error()
 
 
+@mg.mem_guard_off
 def test_catches_bad_constant_propagation():
     def mul2(x, constant=False):
         return mg.multiply(x, 2, constant=False)
@@ -122,6 +125,7 @@ def test_catches_bad_constant_propagation():
         should_catch_error()
 
 
+@mg.mem_guard_off
 def test_catches_mutation_error():
     class Mul2_Mutate(Operation):
         def __call__(self, tensor: Tensor):
@@ -164,6 +168,7 @@ def test_catches_numpy_view_mygrad_copy():
         should_catch_error()
 
 
+@mg.mem_guard_off
 def test_catches_numpy_copy_mygrad_view():
     def copy(x, constant):
         return mg.reshape(x, x.shape, constant=constant)
@@ -182,6 +187,7 @@ def test_catches_numpy_copy_mygrad_view():
         should_catch_error()
 
 
+@mg.mem_guard_off
 def test_bad_constant_propagation():
     def bad_const_prop(x, y, z, constant=False):
         if not constant and any(not i.constant for i in [x, y, z]):
@@ -320,6 +326,8 @@ def tests_catches_input_tensors_memory_not_locked_by_op():
     with pytest.raises(AssertionError):
         should_catch_error()
 
+    clear_all_mem_locking_state()
+
 
 def tests_catches_output_tensors_memory_not_locked_by_op():
     def mul_releases_output_lock(x, y, constant=False):
@@ -336,3 +344,5 @@ def tests_catches_output_tensors_memory_not_locked_by_op():
 
     with pytest.raises(AssertionError):
         should_catch_error()
+
+    clear_all_mem_locking_state()


### PR DESCRIPTION
- bugfixes 
    - unlock view of locked-&-tracked array; handle multiple views waiting for same base for unlock
    - don't force-lock output; was causing read-only tensors to get tracked by mem-locker
    - batchnorm wasn't clearing its state properly for gamma/beta=none
    - fix ref cycles in GRU
    -  clean up stragglers in `_views_waiting_for_unlock` if no tracked arrays remain

Ensure tests don't leak state