### PR TITLE
Add iops

### DIFF
--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -10,7 +10,7 @@ import numpy as np
 from mygrad._utils import SkipGradient, reduce_broadcast
 from mygrad.errors import InvalidBackprop, InvalidGradient
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from mygrad import Tensor
     from mygrad._utils import WeakRef
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -38,6 +38,13 @@ from mygrad.linalg.ops import MatMul
 from mygrad.math.arithmetic.ops import (
     Add,
     Divide,
+    IAdd,
+    IDivide,
+    IMultiply,
+    IPow1,
+    IPower,
+    ISquare,
+    ISubstract,
     Multiply,
     Negative,
     Positive,
@@ -1337,11 +1344,19 @@ class Tensor:
     def __add__(self, other) -> "Tensor":
         return self._op(Add, self, other)
 
+    def __iadd__(self, other) -> "Tensor":
+        self._in_place_op(IAdd, other)
+        return self
+
     def __radd__(self, other) -> "Tensor":
         return self._op(Add, other, self)
 
     def __sub__(self, other) -> "Tensor":
         return self._op(Subtract, self, other)
+
+    def __isub__(self, other) -> "Tensor":
+        self._in_place_op(ISubstract, other)
+        return self
 
     def __rsub__(self, other) -> "Tensor":
         return self._op(Subtract, other, self)
@@ -1352,8 +1367,16 @@ class Tensor:
     def __rtruediv__(self, other) -> "Tensor":
         return self._op(Divide, other, self)
 
+    def __itruediv__(self, other) -> "Tensor":
+        self._in_place_op(IDivide, other)
+        return self
+
     def __mul__(self, other) -> "Tensor":
         return self._op(Multiply, self, other)
+
+    def __imul__(self, other) -> "Tensor":
+        self._in_place_op(IMultiply, other)
+        return self
 
     def __rmul__(self, other) -> "Tensor":
         return self._op(Multiply, other, self)
@@ -1374,6 +1397,20 @@ class Tensor:
                 return self._op(Square, self)
 
         return self._op(Power, self, other)
+
+    def __ipow__(self, other) -> "Tensor":
+        if isinstance(other, Number) or (
+            isinstance(other, np.ndarray) and other.ndim == 0
+        ):
+            if other == 1:
+                self._in_place_op(IPow1)
+                return self
+            elif other == 2:
+                self._in_place_op(ISquare)
+                return self
+
+        self._in_place_op(IPower, other)
+        return self
 
     def __rpow__(self, other):
         return self._op(Power, other, self)

--- a/tests/math/binary/test_binary_funcs.py
+++ b/tests/math/binary/test_binary_funcs.py
@@ -1,11 +1,16 @@
 """ Test all binary arithmetic operations, checks for appropriate broadcast behavior"""
+from functools import partial
+from numbers import Number
+from typing import Any, Dict
 
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
+import pytest
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
+import mygrad as mg
 from mygrad import (
     add,
     arctan2,
@@ -21,7 +26,88 @@ from tests.custom_strategies import tensors
 from ...wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
-@fwdprop_test_factory(mygrad_func=add, true_func=np.add, num_arrays=2)
+def inplace_op(inplace_target, other, constant=False, *, op_name: str):
+
+    op_name = "__" + op_name + "__"
+
+    # hack to make broadcastable shapes work for inplace op:
+    # 1. Ensure that inplace op has at least as many items as `other`.
+    # 2. `other` can't have excess leading dims
+    inplace_target, other = (
+        (inplace_target, other)
+        if inplace_target.size >= other.size
+        else (other, inplace_target)
+    )
+    if other.ndim > inplace_target.ndim:
+        other = other[(0,) * (other.ndim - inplace_target.ndim)]
+
+    # touch so that it doesn't look like the input
+    # was mutated
+    inplace_target = +inplace_target
+    if isinstance(inplace_target, Number):
+        inplace_target = np.asarray(inplace_target)
+
+    getattr(inplace_target, op_name)(other)
+
+    if isinstance(inplace_target, mg.Tensor) and constant:
+        inplace_target._constant = constant
+
+    return inplace_target
+
+
+ipow = partial(inplace_op, op_name="ipow")
+idiv = partial(inplace_op, op_name="itruediv")
+
+
+@pytest.mark.parametrize(
+    ("op_name", "kwargs"),
+    [
+        ("iadd", dict()),
+        ("isub", dict()),
+        ("imul", dict()),
+        ("itruediv", dict(index_to_bnds={0: (1, 100), 1: (1, 100)})),
+        ("ipow", dict(index_to_bnds={0: (1, 4), 1: (1, 4)})),
+    ],
+)
+def test_inplace_arithmetic_fwd(op_name: str, kwargs: Dict[str, Any]):
+    iop = partial(inplace_op, op_name=op_name)
+
+    @fwdprop_test_factory(
+        mygrad_func=iop,
+        true_func=iop,
+        num_arrays=2,
+        permit_0d_array_as_float=False,
+        **kwargs
+    )
+    def iop_fwd():
+        pass
+
+    iop_fwd()
+
+
+@pytest.mark.parametrize(
+    ("op_name", "kwargs"),
+    [
+        ("iadd", dict()),
+        ("isub", dict()),
+        ("imul", dict()),
+        ("itruediv", dict(index_to_bnds={0: (1, 100), 1: (1, 100)})),
+        ("ipow", dict(index_to_bnds={0: (1, 4), 1: (1, 4)})),
+    ],
+)
+def test_inplace_arithmetic_bkwd(op_name: str, kwargs: Dict[str, Any]):
+    iop = partial(inplace_op, op_name=op_name)
+
+    @backprop_test_factory(
+        mygrad_func=iop, true_func=iop, num_arrays=2, vary_each_element=True, **kwargs
+    )
+    def iop_bkwd():
+        pass
+
+    iop_bkwd()
+
+
+@fwdprop_test_factory(mygrad_func=add, true_func=add, num_arrays=2)
 def test_add_fwd():
     pass
 

--- a/tests/tensor_base/test_pow_special_cases.py
+++ b/tests/tensor_base/test_pow_special_cases.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
 import pytest
@@ -11,9 +12,19 @@ from tests.custom_strategies import tensors
 
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
+hnp.mutually_broadcastable_shapes
+
 
 def custom_pow(x, p, constant=False):
     out = x ** p
+    if isinstance(out, mg.Tensor) and constant:
+        out._constant = constant
+    return out
+
+
+def in_place_custom_pow(x, p, constant=False):
+    out = +x
+    out **= p
     if isinstance(out, mg.Tensor) and constant:
         out._constant = constant
     return out
@@ -61,6 +72,27 @@ def test_pow_1_bkwd():
 
 
 @fwdprop_test_factory(
+    mygrad_func=in_place_custom_pow,
+    true_func=in_place_custom_pow,
+    num_arrays=1,
+    kwargs={"p": partial(any_scalar, p=1)},
+    permit_0d_array_as_float=False,
+)
+def test_inplace_pow_1_fwd():
+    pass
+
+
+@backprop_test_factory(
+    mygrad_func=in_place_custom_pow,
+    true_func=in_place_custom_pow,
+    num_arrays=1,
+    kwargs={"p": partial(any_scalar, p=1)},
+)
+def test_inplace_pow_1_bkwd():
+    pass
+
+
+@fwdprop_test_factory(
     mygrad_func=custom_pow,
     true_func=custom_pow,
     num_arrays=1,
@@ -78,4 +110,25 @@ def test_pow_2_fwd():
     kwargs={"p": partial(any_scalar, p=2)},
 )
 def test_pow_2_bkwd():
+    pass
+
+
+@fwdprop_test_factory(
+    mygrad_func=in_place_custom_pow,
+    true_func=in_place_custom_pow,
+    num_arrays=1,
+    kwargs={"p": partial(any_scalar, p=2)},
+    permit_0d_array_as_float=False,
+)
+def test_inplace_pow_2_fwd():
+    pass
+
+
+@backprop_test_factory(
+    mygrad_func=in_place_custom_pow,
+    true_func=in_place_custom_pow,
+    num_arrays=1,
+    kwargs={"p": partial(any_scalar, p=2)},
+)
+def test_inplace_pow_2_bkwd():
     pass

--- a/tests/test_in_place_semantics.py
+++ b/tests/test_in_place_semantics.py
@@ -11,6 +11,131 @@ from mygrad import Tensor
 from tests.custom_strategies import tensors
 
 
+# Make sure we actually test the correctness of the
+# in-place syntaxes, e.g. `x += y`, and not just
+# `x.__iadd__(y)`
+#
+# Also, make sure that augmented updates on tensors
+# match behavior of numpy
+def test_iadd_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an += 2.0
+
+    bt = at
+    vt = at[...]
+    at += 2.0
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
+def test_isub_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an -= 2.0
+
+    bt = at
+    vt = at[...]
+    at -= 2.0
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
+def test_imul_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an *= 2.0
+
+    bt = at
+    vt = at[...]
+    at *= 2.0
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
+def test_idiv_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an /= 2.0
+
+    bt = at
+    vt = at[...]
+    at /= 2.0
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
+def test_ipow_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an **= 2.1
+
+    bt = at
+    vt = at[...]
+    at **= 2.1
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
+def test_isqr_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an **= 2
+
+    bt = at
+    vt = at[...]
+    at **= 2
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
+def test_ipow_1_mirrors_numpy():
+    an = np.array([3.0, 4.0])
+    at = mg.Tensor(an)
+
+    bn = an
+    vn = an[...]
+    an **= 1
+
+    bt = at
+    vt = at[...]
+    at **= 1
+
+    assert_array_equal(an, at)
+    assert_array_equal(bn, bt)
+    assert_array_equal(vn, vt)
+
+
 @pytest.mark.parametrize("inplace_on_view", [True, False])
 def test_raising_during_in_place_op_doesnt_corrupt_graph(inplace_on_view: bool):
     x = mg.arange(1.0, 5.0)


### PR DESCRIPTION
Adds support for augmented updates via arithmetic operators (e.g. `+=`)

As shown in #280, MyGrad use to simply "unroll" augmented updates:
```python
tensor += 2

# was the same as
tensor = tensor + 2
```

Meaning that the update did not actually occur in-place. These augmented updates now mirror NumPy's behavior.

Closes #280