### PR TITLE
Improve parity between Tensor.__init__ and array.__init__

### DIFF
--- a/docs/source/generated/mygrad.Tensor.base.rst
+++ b/docs/source/generated/mygrad.Tensor.base.rst
@@ -1,0 +1,6 @@
+mygrad.Tensor.base
+==================
+
+.. currentmodule:: mygrad
+
+.. automethod:: Tensor.base

--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -137,22 +137,23 @@ Documentation for mygrad.Tensor
    :toctree: generated/
 
    Tensor
-   Tensor.backward
-   Tensor.grad
-   Tensor.null_grad
-   Tensor.shape
-   Tensor.ndim
-   Tensor.size
    Tensor.astype
-   Tensor.dtype
-   Tensor.item
-   Tensor.T
-   Tensor.constant
-   Tensor.scalar_only
-   Tensor.null_gradients
-   Tensor.copy
+   Tensor.backward
+   Tensor.base
    Tensor.clear_graph
+   Tensor.constant
+   Tensor.copy
    Tensor.creator
+   Tensor.dtype
+   Tensor.grad
+   Tensor.item
+   Tensor.ndim
+   Tensor.null_grad
+   Tensor.null_gradients
+   Tensor.scalar_only
+   Tensor.shape
+   Tensor.size
+   Tensor.T
 
 
 

--- a/src/mygrad/nnet/initializers/glorot_normal.py
+++ b/src/mygrad/nnet/initializers/glorot_normal.py
@@ -55,8 +55,5 @@ def glorot_normal(*shape, gain=1, dtype=np.float32, constant=False):
     fan_out = shape[0] * (shape[-1] if len(shape) > 2 else 1)
     std = gain * np.sqrt(2 / (fan_in + fan_out))
     return Tensor(
-        np.random.normal(0, std, shape),
-        dtype=dtype,
-        constant=constant,
-        copy_data=False,
+        np.random.normal(0, std, shape), dtype=dtype, constant=constant, copy=False,
     )

--- a/src/mygrad/nnet/initializers/normal.py
+++ b/src/mygrad/nnet/initializers/normal.py
@@ -57,8 +57,5 @@ def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
         std = std.item()
 
     return Tensor(
-        np.random.normal(mean, std, shape),
-        dtype=dtype,
-        constant=constant,
-        copy_data=False,
+        np.random.normal(mean, std, shape), dtype=dtype, constant=constant, copy=False,
     )

--- a/src/mygrad/nnet/initializers/uniform.py
+++ b/src/mygrad/nnet/initializers/uniform.py
@@ -60,5 +60,5 @@ def uniform(*shape, lower_bound=0, upper_bound=1, dtype=np.float32, constant=Fal
         np.random.uniform(lower_bound, upper_bound, shape),
         dtype=dtype,
         constant=constant,
-        copy_data=False,
+        copy=False,
     )

--- a/src/mygrad/nnet/losses/negative_log_likelihood.py
+++ b/src/mygrad/nnet/losses/negative_log_likelihood.py
@@ -46,12 +46,14 @@ def negative_log_likelihood(x, y_true, *, weights=None, constant=False):
     >>> negative_log_likelihood(x, y_true)
     Tensor(1.09861229)
 
-    # log-probabilities where the prediction is highly-confident and correct
+    Log-probabilities where the prediction is highly-confident and correct:
+
     >>> x = mg.Tensor([[0, -20, -20]])
     >>> negative_log_likelihood(x, y_true)
     Tensor(0.)
 
-    # adding a class-weighting
+    Adding a class-weighting:
+
     >>> x = mg.Tensor([[-4.6, -4.6, -0.02]])
     >>> weights = mg.Tensor([2, 1, 1])
     >>> negative_log_likelihood(x, y_true, weights=weights)

--- a/src/mygrad/random/funcs.py
+++ b/src/mygrad/random/funcs.py
@@ -32,7 +32,7 @@ def rand(*shape, constant=False):
             [0.66029533, 0.79285341, 0.54967228, 0.25178508]])
     """
 
-    return Tensor(np.random.rand(*shape), constant=constant, copy_data=False)
+    return Tensor(np.random.rand(*shape), constant=constant, copy=False)
 
 
 def randint(low, high=None, shape=None, dtype=int, constant=False):
@@ -80,7 +80,7 @@ def randint(low, high=None, shape=None, dtype=int, constant=False):
     """
 
     return Tensor(
-        np.random.randint(low, high, shape, dtype), constant=constant, copy_data=False
+        np.random.randint(low, high, shape, dtype), constant=constant, copy=False
     )
 
 
@@ -120,7 +120,7 @@ def randn(*shape, constant=False):
              [-1.28788909, -1.52525778]]])
     """
 
-    return Tensor(np.random.randn(*shape), constant=constant, copy_data=False)
+    return Tensor(np.random.randn(*shape), constant=constant, copy=False)
 
 
 def random(shape=None, constant=False):
@@ -153,7 +153,7 @@ def random(shape=None, constant=False):
             [0.19780163, 0.51162365, 0.7849505 , 0.47864586]])
     """
 
-    return Tensor(np.random.random(shape), constant=constant, copy_data=False)
+    return Tensor(np.random.random(shape), constant=constant, copy=False)
 
 
 def random_sample(shape=None, constant=False):
@@ -192,7 +192,7 @@ def random_sample(shape=None, constant=False):
     Tensor(0.47644928)
     """
 
-    return Tensor(np.random.random_sample(shape), constant=constant, copy_data=False)
+    return Tensor(np.random.random_sample(shape), constant=constant, copy=False)
 
 
 def ranf(shape=None, constant=False):
@@ -233,7 +233,7 @@ def ranf(shape=None, constant=False):
     Tensor(0.77739196)
     """
 
-    return Tensor(np.random.ranf(shape), constant=constant, copy_data=False)
+    return Tensor(np.random.ranf(shape), constant=constant, copy=False)
 
 
 def sample(shape=None, constant=False):
@@ -270,7 +270,7 @@ def sample(shape=None, constant=False):
     Tensor(0.50690423)
     """
 
-    return Tensor(np.random.sample(shape), constant=constant, copy_data=False)
+    return Tensor(np.random.sample(shape), constant=constant, copy=False)
 
 
 def seed(seed_number):

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -414,8 +414,8 @@ class Tensor:
             back propagation; `self.grad` will always return ``None``.
 
         copy : Optional[bool]
-            Determines if the incoming array-data will be copied. It ``None``,
-            then the data will be copied of ``constant=False`` is specified.
+            Determines if the incoming array-data will be copied. If ``None``,
+            then the data will be copied only if ``constant=False`` is specified.
 
         ndmin : int, optional
             Specifies the minimum number of dimensions that the resulting

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1002,6 +1002,16 @@ class Tensor:
         computational graph will have their writeability restored.
 
         Examples
+        --------
+        >>> import mygrad as mg
+        >>> import numpy as np
+        >>> x = np.array([1., 2.])
+        >>> y = mg.multiply(2., x)
+        >>> x.flags.writeable, y.creator
+        (False, <mygrad.math.arithmetic.ops.Multiply at 0x224f89cac48>)
+        >>> y.clear_graph()
+        >>> x.flags.writeable, y.creator
+        (True, None)
         """
         if self._base is not None:
             # "pull" on grad to force views to update their
@@ -1023,7 +1033,7 @@ class Tensor:
 
     @property
     def scalar_only(self) -> bool:
-        """ Indicates whether or not `self.ndim` must be 0 in order to invoke ``self.backward()``.
+        r""" Indicates whether or not `self.ndim` must be 0 in order to invoke ``self.backward()``.
 
         E.g. a computational graph that involves a broadcast-multiplication of a non-constant
         tensor can only support back-propagation from a scalar. Otherwise the gradient associated
@@ -1038,8 +1048,8 @@ class Tensor:
         Notes
         -----
         In the following example, see that, because ``x`` was broadcasted to a
-        shape-(2, 3) tensor, the derivative :math:`df/dx` could not be a shape-(3,) tensor.
-        Each element of ``x`` affects two entries of ``z``, thus :math:`df/dx`
+        shape-(2, 3) tensor, the derivative :math:`d\mathscr{L}/dx` could not be a shape-(3,) tensor.
+        Each element of ``x`` affects two entries of ``z``, thus :math:`d\mathscr{L}/dx`
         would have to be a shape-(2, 3) array. Therefore ``z.scalar_only`` returns ``True``.
 
         Examples
@@ -1048,8 +1058,8 @@ class Tensor:
         >>> x = mg.Tensor([1., 2., 3.])  # shape-(3,)
         >>> y = mg.Tensor([[4., 1., 9.], # shape-(2, 3)
         ...                [0., 2., 8.]])
-        >>> z = x * y  # uses numpy-style broadcasting
-        >>> z.scalar_only
+        >>> ℒ = x * y  # uses numpy-style broadcasting
+        >>> ℒ.scalar_only
         True
         """
         return self._scalar_only
@@ -1421,6 +1431,17 @@ class Tensor:
         ...                [4, 5, 6]])
         >>> y.shape
         (2, 3)
+
+        The shape attribute can also be set to reshape the tensor in-place
+
+        >>> y.shape = (1, 6, 1)
+        >>> y
+        Tensor([[[1],
+                 [2],
+                 [3],
+                 [4],
+                 [5],
+                 [6]]])
 
         See Also
         --------

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1734,9 +1734,11 @@ class Tensor:
     @property
     def base(self) -> Optional["Tensor"]:
         """
-        A reference to the base tensor if memory is from other tensor
+        A reference to the base tensor that the present tensor is a view of.
 
-         Examples
+        It this tensor owns its memory, then this returns ``None``.
+
+        Examples
         --------
         The base of a tensor that owns its memory is ``None``:
 

--- a/src/mygrad/tensor_creation/funcs.py
+++ b/src/mygrad/tensor_creation/funcs.py
@@ -89,15 +89,22 @@ def empty_like(other, dtype=None, constant=False):
         Tensor
             A tensor of uninitialized data whose shape and type match `other`.
 
+        See Also
+        --------
+        empty : Return a new Tensor of the given shape and type, without initializing entries.
+        ones : Return a new tensor setting values to one.
+        zeros : Return a new tensor setting values to zero.
+        full : Return a new tensor of given shape filled with value.
+
         Examples
         --------
         >>> import mygrad as mg
-        >>> x = mg.arange(4).reshape
-        >>> mg.empty(x, constant=True)
+        >>> x = mg.arange(4).reshape(2, 2)
+        >>> mg.empty_like(x, constant=True)
         Tensor([[ -9.74499359e+001,   6.69583040e-309],
                 [  2.13182611e-314,   3.06959433e-309]])         #random
 
-        >>> mg.empty(x, dtype=int)
+        >>> mg.empty_like(x, dtype=int)
         Tensor([[-1073741821, -1067949133],
                 [  496041986,    19249760]])                     #random
     """

--- a/src/mygrad/tensor_creation/funcs.py
+++ b/src/mygrad/tensor_creation/funcs.py
@@ -66,7 +66,7 @@ def empty(shape, dtype=np.float32, constant=False):
         Tensor([[-1073741821, -1067949133],
                 [  496041986,    19249760]])                     #random
     """
-    return Tensor(np.empty(shape, dtype), constant=constant, copy_data=False)
+    return Tensor(np.empty(shape, dtype), constant=constant, copy=False)
 
 
 def empty_like(other, dtype=None, constant=False):
@@ -101,9 +101,7 @@ def empty_like(other, dtype=None, constant=False):
         Tensor([[-1073741821, -1067949133],
                 [  496041986,    19249760]])                     #random
     """
-    return Tensor(
-        np.empty_like(asarray(other), dtype), constant=constant, copy_data=False
-    )
+    return Tensor(np.empty_like(asarray(other), dtype), constant=constant, copy=False)
 
 
 def eye(rows, cols=None, diag_idx=0, dtype=np.float32, constant=False):
@@ -144,9 +142,7 @@ def eye(rows, cols=None, diag_idx=0, dtype=np.float32, constant=False):
                 [ 0.,  0.,  1.],
                 [ 0.,  0.,  0.]])
     """
-    return Tensor(
-        np.eye(rows, cols, diag_idx, dtype), constant=constant, copy_data=False
-    )
+    return Tensor(np.eye(rows, cols, diag_idx, dtype), constant=constant, copy=False)
 
 
 def identity(n, dtype=np.float32, constant=False):
@@ -177,7 +173,7 @@ def identity(n, dtype=np.float32, constant=False):
                 [ 0.,  1.,  0.],
                 [ 0.,  0.,  1.]])
     """
-    return Tensor(np.identity(n, dtype), constant=constant, copy_data=False)
+    return Tensor(np.identity(n, dtype), constant=constant, copy=False)
 
 
 def ones(shape, dtype=np.float32, constant=False):
@@ -226,7 +222,7 @@ def ones(shape, dtype=np.float32, constant=False):
     Tensor([[ 1.,  1.],
             [ 1.,  1.]])
     """
-    return Tensor(np.ones(shape, dtype), constant=constant, copy_data=False)
+    return Tensor(np.ones(shape, dtype), constant=constant, copy=False)
 
 
 def ones_like(other, dtype=None, constant=False):
@@ -269,9 +265,7 @@ def ones_like(other, dtype=None, constant=False):
     >>> mg.ones_like(y)
     Tensor([ 1.,  1.,  1.])
     """
-    return Tensor(
-        np.ones_like(asarray(other), dtype), constant=constant, copy_data=False
-    )
+    return Tensor(np.ones_like(asarray(other), dtype), constant=constant, copy=False)
 
 
 def zeros(shape, dtype=np.float32, constant=False):
@@ -319,7 +313,7 @@ def zeros(shape, dtype=np.float32, constant=False):
     Tensor([[ 0.,  0.],
             [ 0.,  0.]])
     """
-    return Tensor(np.zeros(shape, dtype), constant=constant, copy_data=False)
+    return Tensor(np.zeros(shape, dtype), constant=constant, copy=False)
 
 
 def zeros_like(other, dtype=None, constant=False):
@@ -369,9 +363,7 @@ def zeros_like(other, dtype=None, constant=False):
     >>> mg.zeros_like(y)
     Tensor([ 0.,  0.,  0.])
     """
-    return Tensor(
-        np.zeros_like(asarray(other), dtype), constant=constant, copy_data=False
-    )
+    return Tensor(np.zeros_like(asarray(other), dtype), constant=constant, copy=False)
 
 
 def full(shape, fill_value, dtype=None, constant=False):
@@ -409,7 +401,7 @@ def full(shape, fill_value, dtype=None, constant=False):
     Tensor([[10, 10],
             [10, 10]])
     """
-    return Tensor(np.full(shape, fill_value, dtype), constant=constant, copy_data=False)
+    return Tensor(np.full(shape, fill_value, dtype), constant=constant, copy=False)
 
 
 def full_like(other, fill_value, dtype=None, constant=False):
@@ -450,9 +442,7 @@ def full_like(other, fill_value, dtype=None, constant=False):
         Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
     """
     return Tensor(
-        np.full_like(asarray(other), fill_value, dtype),
-        constant=constant,
-        copy_data=False,
+        np.full_like(asarray(other), fill_value, dtype), constant=constant, copy=False,
     )
 
 
@@ -501,9 +491,7 @@ def arange(stop, start=0, step=1, dtype=None, constant=False):
         tmp = start
         start = stop
         stop = tmp
-    return Tensor(
-        np.arange(start, stop, step, dtype), constant=constant, copy_data=False
-    )
+    return Tensor(np.arange(start, stop, step, dtype), constant=constant, copy=False)
 
 
 def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=False):
@@ -556,7 +544,7 @@ def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=Fa
     return Tensor(
         np.linspace(start, stop, num, include_endpoint, dtype=dtype),
         constant=constant,
-        copy_data=False,
+        copy=False,
     )
 
 
@@ -621,7 +609,7 @@ def logspace(
     return Tensor(
         np.logspace(start, stop, num, include_endpoint, base, dtype),
         constant=constant,
-        copy_data=False,
+        copy=False,
     )
 
 
@@ -696,5 +684,5 @@ def geomspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=F
     return Tensor(
         np.geomspace(start, stop, num, include_endpoint, dtype),
         constant=constant,
-        copy_data=False,
+        copy=False,
     )

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -97,6 +97,7 @@ def tensors(
         min_dims=0, min_side=0
     ),
     *,
+    ndmin: int = 0,
     elements: Optional[st.SearchStrategy[Any]] = None,
     fill: Optional[st.SearchStrategy[Any]] = None,
     unique: bool = False,
@@ -142,6 +143,11 @@ def tensors(
         it to return are NaN values (anything for which :obj:`numpy:numpy.isnan`
         returns True. So e.g. for complex numbers (nan+1j) is also a valid fill).
         Note that if unique is set to True the generated values must be hashable.
+
+    ndmin : int, optional
+        Specifies the minimum number of dimensions that the resulting
+        array should have.  Ones will be pre-pended to the shape as
+        needed to meet this requirement.
 
     constant : Union[bool, st.SearchStrategy[bool]]
         Specifies ``tensor.constant``. Default is :func:`~hypothesis.strategies.booleans`
@@ -223,7 +229,7 @@ def tensors(
 
     constant = draw(constant) if isinstance(constant, st.SearchStrategy) else constant
 
-    tensor = VerboseTensor(x, constant=constant, copy_data=False)
+    tensor = VerboseTensor(x, constant=constant, copy=False, ndmin=ndmin)
     if isinstance(include_grad, st.SearchStrategy):
         include_grad = draw(include_grad)
 
@@ -239,7 +245,7 @@ def tensors(
         tensor._grad = draw(
             hnp.arrays(
                 dtype=grad_dtype,
-                shape=x.shape,
+                shape=tensor.shape,
                 elements=st.floats(
                     *grad_elements_bounds, width=grad_dtype.itemsize * 8
                 ),

--- a/tests/custom_strategies/test_strategies.py
+++ b/tests/custom_strategies/test_strategies.py
@@ -289,3 +289,17 @@ def test_tensor_read_only_default(tensor: Tensor):
 def test_tensor_read_only(data: st.DataObject, read_only: bool):
     tensor = data.draw(tensors(read_only=read_only))
     assert tensor.data.flags.writeable is not read_only
+
+
+@given(
+    shape=hnp.array_shapes(min_dims=0, min_side=0),
+    ndmin=st.integers(0, 10),
+    data=st.data(),
+)
+def test_tensor_ndmin(shape: Tuple[int, ...], ndmin: int, data: st.DataObject):
+    tensor = data.draw(
+        tensors(shape=shape, ndmin=ndmin, include_grad=True, read_only=st.booleans()),
+        label="tensor",
+    )
+    assert tensor.ndim >= ndmin
+    assert tensor.shape == tensor.grad.shape


### PR DESCRIPTION
- `Tensor(..., copy=<val>)` now matches `array(..., copy=<val>)`
- Added `Tensor(..., ndmin=<val>)`, to match that of `array`
- Improves some docs