### PR TITLE
Dtype int

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -354,6 +354,22 @@ can always be interpreted as an array of scalar-valued derivatives.
 +---------------------------------------------+---------------------------------------+
 
 
+Integer-valued Tensors Are Treated as Constants
+-----------------------------------------------
+
+Derivatives involving integer-valued tensors are typically ill-defined, and in MyGrad 1.X they
+were generally just wrong. Now integer-valued tensors can only be involved in computational
+graphs as constants.
+
++---------------------------------------------+-------------------------------------------------+
+| MyGrad 1.X                                  | MyGrad 2.0                                      |
++=============================================+=================================================+
+| .. code:: python                            | .. code:: python                                |
+|                                             |                                                 |
+|    >>> t1 = mg.Tensor([[1, 2]).constant     |    >>> t1 = mg.Tensor([[1, 2]]).constant        |
+|    False                                    |    True
++---------------------------------------------+-------------------------------------------------+
+
 Is This Code Well-Tested?
 -------------------------
 

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -367,7 +367,7 @@ graphs as constants.
 | .. code:: python                            | .. code:: python                                |
 |                                             |                                                 |
 |    >>> t1 = mg.Tensor([[1, 2]).constant     |    >>> t1 = mg.Tensor([[1, 2]]).constant        |
-|    False                                    |    True
+|    False                                    |    True                                         |
 +---------------------------------------------+-------------------------------------------------+
 
 Is This Code Well-Tested?

--- a/docs/source/tensor.rst
+++ b/docs/source/tensor.rst
@@ -39,6 +39,15 @@ Tensor([[1, 2],
 >>> mg.arange(4)    # using numpy-style tensor creation functions
 Tensor([0, 1, 2, 3])
 
+Integer-valued tensors are treated as constants
+
+>>> mg.astensor(1, dtype=np.int8).constant
+True
+
+By default, float-valued tensors are not treated as constants
+
+>>> mg.astensor(1, dtype=np.float32).constant
+False
 
 Forward and Back-Propagation
 ----------------------------

--- a/src/mygrad/nnet/activations/softmax.py
+++ b/src/mygrad/nnet/activations/softmax.py
@@ -6,15 +6,17 @@ from mygrad.tensor_base import Tensor
 
 
 def _softmax(x, kwargs):
-    x = x - x.max(**kwargs)
-    if np.issubdtype(x.dtype, np.integer):
-        x = x.astype(np.float)
-    if x.ndim > 0:
-        np.exp(x, out=x)
-        x /= x.sum(**kwargs)
+
+    if x.ndim > 0 and x.size > 0:
+        x = x - x.max(**kwargs)
+        target = x.astype(np.float) if issubclass(x.dtype.type, np.integer) else x
+
+        target = np.exp(x, out=target)
+        target /= target.sum(**kwargs)
     else:
-        x = np.ones_like(x)
-    return x
+        target = x.astype(np.float) if issubclass(x.dtype.type, np.integer) else x
+        target = np.ones_like(target)
+    return target
 
 
 class Softmax(Operation):

--- a/src/mygrad/random/funcs.py
+++ b/src/mygrad/random/funcs.py
@@ -35,9 +35,10 @@ def rand(*shape, constant=False):
     return Tensor(np.random.rand(*shape), constant=constant, copy=False)
 
 
-def randint(low, high=None, shape=None, dtype=int, constant=False):
+def randint(low, high=None, shape=None, dtype=int):
     """ Return random integers from the “discrete uniform” distribution of the specified dtype in the
     “half-open” interval [low, high).
+
     If high is None (the default), then results are from [0, low).
 
     Parameters
@@ -57,11 +58,6 @@ def randint(low, high=None, shape=None, dtype=int, constant=False):
     dtype: dtype, optional
         Desired dtype of the result. Byteorder must be native. The default value is int.
 
-    constant : bool, optional (default=False)
-        If ``True``, the returned tensor is a constant (it
-        does not back-propagate a gradient)
-
-
     Returns
     -------
     int or mygrad.Tensor of ints
@@ -79,9 +75,7 @@ def randint(low, high=None, shape=None, dtype=int, constant=False):
     Tensor(57)
     """
 
-    return Tensor(
-        np.random.randint(low, high, shape, dtype), constant=constant, copy=False
-    )
+    return Tensor(np.random.randint(low, high, shape, dtype), copy=False)
 
 
 def randn(*shape, constant=False):

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -436,7 +436,7 @@ class Tensor:
             Points to the tensor that ``self`` shares memory with.
         """
 
-        if constant not in {None, True, False}:  # faster than `isinstance(x, bool)`
+        if constant is not None and not isinstance(constant, bool):
             raise TypeError(f"`constant` must be a boolean value, got: {constant}")
 
         self._creator = _creator  # type: Union[None, Operation]

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -572,11 +572,10 @@ class Tensor:
     def astype(
         self, dtype: Union[type, str], *, constant: Optional[bool] = None
     ) -> "Tensor":
-        """Returns a distinct tensor with its data modified to have the specified
-        data type.
+        """Copy of the tensor with the specified dtype.
 
-        The resulting tensor does not belong to any pre-existing computation graph; i.e.
-        it is as if this tensor was created 'from scratch'.
+        The resulting tensor is not involved in any computational graph
+        and has no gradient associated with it.
 
         Parameters
         ----------
@@ -611,8 +610,7 @@ class Tensor:
         >>> x.astype(np.int8, constant=True)
         Tensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=int8)
         """
-        constant = constant if constant is not None else self.constant
-        return type(self)(self.data.astype(dtype), constant=constant)
+        return type(self)(self.data, dtype=dtype, copy=True, constant=constant)
 
     @classmethod
     def _op(

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -32,7 +32,7 @@ from mygrad._utils import (
     collect_all_operations,
     is_invalid_gradient,
 )
-from mygrad.errors import DisconnectedView, InvalidBackprop, InvalidGradient
+from mygrad.errors import DisconnectedView, InvalidGradient
 from mygrad.linalg.ops import MatMul
 from mygrad.math.arithmetic.ops import (
     Add,

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -223,7 +223,7 @@ def astensor(t, dtype=None, constant: bool = None) -> "Tensor":
             # return tensor as-as
             return t
 
-        if constant is None:
+        if constant is None and dtype is None:
             constant = t.constant
     return Tensor(t, dtype=dtype, constant=constant)
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -657,7 +657,7 @@ class Tensor:
             # lock memory of array data and clear any tensor
             # gradients
             tensor_vars = tuple(
-                cls(var, constant=True)
+                cls(var, constant=True, copy=False)
                 if not isinstance(var, Tensor)
                 else var.null_grad(_clear_view_info=True)
                 for var in input_vars
@@ -672,7 +672,9 @@ class Tensor:
         else:
             # operations are not being tracked - don't lock memory or null grads
             tensor_vars = tuple(
-                cls(var, constant=True) if not isinstance(var, Tensor) else var
+                cls(var, constant=True, copy=False)
+                if not isinstance(var, Tensor)
+                else var
                 for var in input_vars
             )
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -221,9 +221,6 @@ def astensor(t, dtype=None, constant: bool = None) -> "Tensor":
             # return tensor as-as
             return t
 
-        if constant is None and dtype is None:
-            constant = t.constant
-
     return Tensor(t, dtype=dtype, constant=constant, copy=False)
 
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -154,6 +154,11 @@ def astensor(t, dtype=None, constant: bool = None) -> "Tensor":
         By default, `constant` is inferred from `t` if `t` is a tensor,
         otherwise it defaults to `False`.
 
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
+
     Returns
     -------
     out : Tensor
@@ -402,8 +407,9 @@ class Tensor:
             data type is inferred from ``x`` via ``numpy.asarray(x)``.
 
         constant : Optional[bool]
-            If True, this node is treated as a constant, and thus does not facilitate
-            back propagation (i.e. `self.grad` will always return ``None``).
+            If ``True``, this tensor is treated as a constant, and thus does not
+            facilitate back propagation (i.e. `self.grad` will always return
+            ``None``).
 
             Defaults to ``False`` for float-type data.
             Defaults to ``True`` for integer-type data.

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -173,7 +173,7 @@ def astensor(t, dtype=None, constant: bool = None) -> "Tensor":
     Convert an array into a tensor. No copy of the
     underlying numpy array is created:
 
-    >>> a = np.array([1, 2.])
+    >>> a = np.array([1.0, 2.0])
     >>> mg.astensor(a)
     Tensor([1., 2.])
     >>> a is mg.astensor(a).data
@@ -198,13 +198,6 @@ def astensor(t, dtype=None, constant: bool = None) -> "Tensor":
     >>> mg.astensor(t, dtype=np.float64) is t
     False
 
-    Creating a non-constant tensor from a constant tensor will copy
-    the underlying data.
-
-    >>> t = mg.Tensor([1, 2], constant=True)
-    >>> mg.astensor(t, constant=False).data is t.data
-    False
-
     Otherwise, if `constant` is set, a new tensor is created (with
     no copy of the underlying data) only if constant doesn't match.
 
@@ -225,7 +218,8 @@ def astensor(t, dtype=None, constant: bool = None) -> "Tensor":
 
         if constant is None and dtype is None:
             constant = t.constant
-    return Tensor(t, dtype=dtype, constant=constant)
+
+    return Tensor(t, dtype=dtype, constant=constant, copy=False)
 
 
 class Tensor:

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -457,7 +457,7 @@ class Tensor:
             elif constant is False:
                 raise ValueError("Integer-valued tensors must be treated as constants.")
         if constant is None:
-            # int: default constant -> True
+            # non-float: default constant -> True
             # float: default constant -> False
             constant = not is_float
 
@@ -1034,8 +1034,8 @@ class Tensor:
         Additionally, any tensor that is a descendant of constant tensors will also
         be a constant.
 
-        Python scalars and NumPy arrays are treated as constant tensors when included
-        in MyGrad computational graphs.
+        Integer-valued tesnors, Python scalars and NumPy arrays are treated as constant
+        tensors when included in MyGrad computational graphs.
 
         Returns
         -------
@@ -1064,6 +1064,11 @@ class Tensor:
         >>> y = mg.Tensor([0., 3.], constant=True)
         >>> z = (x + y) ** 2 - np.array([8., 7.])
         >>> z.constant
+        True
+
+        Integer-valued tensors are treated as constants
+
+        >>> mg.Tensor([1, 2]).constant
         True
         """
         return self._constant

--- a/src/mygrad/tensor_creation/funcs.py
+++ b/src/mygrad/tensor_creation/funcs.py
@@ -453,7 +453,7 @@ def full_like(other, fill_value, dtype=None, constant=False):
     )
 
 
-def arange(stop, start=0, step=1, dtype=None, constant=False):
+def arange(stop, start=0, step=1, dtype=None, constant=None):
     """ Return a Tensor with evenly-spaced values within a given interval.
 
         Values are generated within [start, stop). Note that for non-integer steps, results may be

--- a/src/mygrad/tensor_creation/funcs.py
+++ b/src/mygrad/tensor_creation/funcs.py
@@ -20,170 +20,190 @@ __all__ = [
 ]
 
 
-def empty(shape, dtype=np.float32, constant=False):
+def empty(shape, dtype=np.float32, constant=None):
     """ Return a new Tensor of the given shape and type, without initializing entries.
 
-        Parameters
-        ----------
-        shape : Union[int, Tuple[int]]
-            The shape of the empty array.
+    Parameters
+    ----------
+    shape : Union[int, Tuple[int]]
+        The shape of the empty array.
 
-        dtype : data-type, optional (default=numpy.float32)
-            The data type of the output Tensor.
+    dtype : data-type, optional (default=numpy.float32)
+        The data type of the output Tensor.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A tensor of uninitialized data of the given shape and dtype.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        See Also
-        --------
-        empty_like : Return an empty tensor with shape and type of input.
-        ones : Return a new tensor setting values to one.
-        zeros : Return a new tensor setting values to zero.
-        full : Return a new tensor of given shape filled with value.
+        Integer-type tensors must be constant.
+
+    Returns
+    -------
+    Tensor
+        A tensor of uninitialized data of the given shape and dtype.
+
+    See Also
+    --------
+    empty_like : Return an empty tensor with shape and type of input.
+    ones : Return a new tensor setting values to one.
+    zeros : Return a new tensor setting values to zero.
+    full : Return a new tensor of given shape filled with value.
 
 
-        Notes
-        -----
-        `empty`, unlike `zeros`, does not set the array values to zero,
-        and may therefore be marginally faster.  On the other hand, it requires
-        the user to manually set all the values in the array, and should be
-        used with caution.
+    Notes
+    -----
+    `empty`, unlike `zeros`, does not set the array values to zero,
+    and may therefore be marginally faster.  On the other hand, it requires
+    the user to manually set all the values in the array, and should be
+    used with caution.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> mg.empty([2, 2], constant=True)
-        Tensor([[ -9.74499359e+001,   6.69583040e-309],
-                [  2.13182611e-314,   3.06959433e-309]])         #random
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> mg.empty([2, 2], constant=True)
+    Tensor([[ -9.74499359e+001,   6.69583040e-309],
+            [  2.13182611e-314,   3.06959433e-309]])         #random
 
-        >>> mg.empty([2, 2], dtype=int)
-        Tensor([[-1073741821, -1067949133],
-                [  496041986,    19249760]])                     #random
+    >>> mg.empty([2, 2], dtype=int)
+    Tensor([[-1073741821, -1067949133],
+            [  496041986,    19249760]])                     #random
     """
     return Tensor(np.empty(shape, dtype), constant=constant, copy=False)
 
 
-def empty_like(other, dtype=None, constant=False):
+def empty_like(other, dtype=None, constant=None):
     """ Return a new Tensor of the same shape and type as the given array.
 
-        Parameters
-        ----------
-        other : Union[Tensor, ArrayLike]
-            The Tensor or array whose shape and datatype should be mirrored.
+    Parameters
+    ----------
+    other : Union[Tensor, ArrayLike]
+        The Tensor or array whose shape and datatype should be mirrored.
 
-        dtype : data-type, optional (default=None)
-            Override the data type of the returned Tensor with this value, or None to not override.
+    dtype : data-type, optional (default=None)
+        Override the data type of the returned Tensor with this value, or None to not override.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A tensor of uninitialized data whose shape and type match `other`.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        See Also
-        --------
-        empty : Return a new Tensor of the given shape and type, without initializing entries.
-        ones : Return a new tensor setting values to one.
-        zeros : Return a new tensor setting values to zero.
-        full : Return a new tensor of given shape filled with value.
+        Integer-type tensors must be constant.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> x = mg.arange(4).reshape(2, 2)
-        >>> mg.empty_like(x, constant=True)
-        Tensor([[ -9.74499359e+001,   6.69583040e-309],
-                [  2.13182611e-314,   3.06959433e-309]])         #random
+    Returns
+    -------
+    Tensor
+        A tensor of uninitialized data whose shape and type match `other`.
 
-        >>> mg.empty_like(x, dtype=int)
-        Tensor([[-1073741821, -1067949133],
-                [  496041986,    19249760]])                     #random
+    See Also
+    --------
+    empty : Return a new Tensor of the given shape and type, without initializing entries.
+    ones : Return a new tensor setting values to one.
+    zeros : Return a new tensor setting values to zero.
+    full : Return a new tensor of given shape filled with value.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> x = mg.arange(4).reshape(2, 2)
+    >>> mg.empty_like(x, constant=True)
+    Tensor([[ -9.74499359e+001,   6.69583040e-309],
+            [  2.13182611e-314,   3.06959433e-309]])         #random
+
+    >>> mg.empty_like(x, dtype=int)
+    Tensor([[-1073741821, -1067949133],
+            [  496041986,    19249760]])                     #random
     """
     return Tensor(np.empty_like(asarray(other), dtype), constant=constant, copy=False)
 
 
-def eye(rows, cols=None, diag_idx=0, dtype=np.float32, constant=False):
+def eye(rows, cols=None, diag_idx=0, dtype=np.float32, constant=None):
     """ Return a 2D Tensor with ones on the diagonal and zeros elsewhere.
 
-        Parameters
-        ----------
-        rows : int
-            The number of rows in the output Tensor.
+    Parameters
+    ----------
+    rows : int
+        The number of rows in the output Tensor.
 
-        cols : int, optional (default=None)
-            The number of columns in the output, or None to match `rows`.
+    cols : int, optional (default=None)
+        The number of columns in the output, or None to match `rows`.
 
-        diag_idx : int, optional (default=0)
-            The index of the diagonal. 0 is the main diagonal; a positive value is the upper
-            diagonal, while a negative value refers to the lower diagonal.
+    diag_idx : int, optional (default=0)
+        The index of the diagonal. 0 is the main diagonal; a positive value is the upper
+        diagonal, while a negative value refers to the lower diagonal.
 
-        dtype : data-type, optional (default=numpy.float32)
-            The data type of the output Tensor.
+    dtype : data-type, optional (default=numpy.float32)
+        The data type of the output Tensor.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A tensor whose elements are 0, except for the :math:`k`-th diagonal, whose values are 1.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> mg.eye(2, dtype=int)
-        Tensor([[1, 0],
-                [0, 1]])
-        >>> mg.eye(3, k=1)
-        Tensor([[ 0.,  1.,  0.],
-                [ 0.,  0.,  1.],
-                [ 0.,  0.,  0.]])
+        Integer-type tensors must be constant.
+
+    Returns
+    -------
+    Tensor
+        A tensor whose elements are 0, except for the :math:`k`-th diagonal, whose values are 1.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> mg.eye(2, dtype=int)
+    Tensor([[1, 0],
+            [0, 1]])
+    >>> mg.eye(3, k=1)
+    Tensor([[ 0.,  1.,  0.],
+            [ 0.,  0.,  1.],
+            [ 0.,  0.,  0.]])
     """
     return Tensor(np.eye(rows, cols, diag_idx, dtype), constant=constant, copy=False)
 
 
-def identity(n, dtype=np.float32, constant=False):
+def identity(n, dtype=np.float32, constant=None):
     """ Return the identity Tensor; a square Tensor with 1s on the main diagonal and 0s elsewhere.
 
-        Parameters
-        ----------
-        n : int
-            The number of rows and columns in the output Tensor.
+    Parameters
+    ----------
+    n : int
+        The number of rows and columns in the output Tensor.
 
-        dtype : data-type, optional (default=numpy.float32)
-            The data type of the output Tensor.
+    dtype : data-type, optional (default=numpy.float32)
+        The data type of the output Tensor.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A square Tensor whose main diagonal is 1 and all other elements are 0.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        Examples
-        --------
-        >>> importy mygrad as mg
-        >>> mg.identity(3)
-        Tensor([[ 1.,  0.,  0.],
-                [ 0.,  1.,  0.],
-                [ 0.,  0.,  1.]])
+        Integer-type tensors must be constant.
+
+    Returns
+    -------
+    Tensor
+        A square Tensor whose main diagonal is 1 and all other elements are 0.
+
+    Examples
+    --------
+    >>> importy mygrad as mg
+    >>> mg.identity(3)
+    Tensor([[ 1.,  0.,  0.],
+            [ 0.,  1.,  0.],
+            [ 0.,  0.,  1.]])
     """
     return Tensor(np.identity(n, dtype), constant=constant, copy=False)
 
 
-def ones(shape, dtype=np.float32, constant=False):
+def ones(shape, dtype=np.float32, constant=None):
     """
     Return a Tensor of the given shape and type, filled with ones.
 
@@ -195,9 +215,14 @@ def ones(shape, dtype=np.float32, constant=False):
     dtype : data-type, optional (default=numpy.float32)
         The data type of the output Tensor.
 
-    constant : bool, optional (default=False)
-        If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
+
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
 
     Returns
     -------
@@ -232,7 +257,7 @@ def ones(shape, dtype=np.float32, constant=False):
     return Tensor(np.ones(shape, dtype), constant=constant, copy=False)
 
 
-def ones_like(other, dtype=None, constant=False):
+def ones_like(other, dtype=None, constant=None):
     """
     Return a Tensor of the same shape and type as the given, filled with ones.
 
@@ -244,9 +269,14 @@ def ones_like(other, dtype=None, constant=False):
     dtype : data-type, optional (default=None)
         Override the data type of the returned Tensor with this value, or None to not override.
 
-    constant : bool, optional (default=False)
-        If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
+
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
 
     Returns
     -------
@@ -275,7 +305,7 @@ def ones_like(other, dtype=None, constant=False):
     return Tensor(np.ones_like(asarray(other), dtype), constant=constant, copy=False)
 
 
-def zeros(shape, dtype=np.float32, constant=False):
+def zeros(shape, dtype=np.float32, constant=None):
     """
     Return a Tensor of the given shape and type, filled with zeros.
 
@@ -287,9 +317,14 @@ def zeros(shape, dtype=np.float32, constant=False):
     dtype : data-type, optional (default=numpy.float32)
         The data type of the output Tensor.
 
-    constant : bool, optional (default=False)
-        If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
+
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
 
     Returns
     -------
@@ -323,7 +358,7 @@ def zeros(shape, dtype=np.float32, constant=False):
     return Tensor(np.zeros(shape, dtype), constant=constant, copy=False)
 
 
-def zeros_like(other, dtype=None, constant=False):
+def zeros_like(other, dtype=None, constant=None):
     """
     Return a Tensor of the same shape and type as the given, filled with zeros.
 
@@ -335,9 +370,15 @@ def zeros_like(other, dtype=None, constant=False):
     dtype : data-type, optional (default=None)
         Override the data type of the returned Tensor with this value, or None to not override.
 
-    constant : bool, optional (default=False)
-        If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
+
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
+
 
     Returns
     -------
@@ -373,7 +414,7 @@ def zeros_like(other, dtype=None, constant=False):
     return Tensor(np.zeros_like(asarray(other), dtype), constant=constant, copy=False)
 
 
-def full(shape, fill_value, dtype=None, constant=False):
+def full(shape, fill_value, dtype=None, constant=None):
     """
     Return a Tensor of the given shape and type, filled with `fill_value`.
 
@@ -388,9 +429,14 @@ def full(shape, fill_value, dtype=None, constant=False):
     dtype : data-type, optional (default=None)
         The data type of the output Tensor, or None to match `fill_value`..
 
-    constant : bool, optional (default=False)
-        If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
+
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
 
     Returns
     -------
@@ -411,42 +457,47 @@ def full(shape, fill_value, dtype=None, constant=False):
     return Tensor(np.full(shape, fill_value, dtype), constant=constant, copy=False)
 
 
-def full_like(other, fill_value, dtype=None, constant=False):
+def full_like(other, fill_value, dtype=None, constant=None):
     """ Return a Tensor of the same shape and type as the given, filled with `fill_value`.
 
-        Parameters
-        ----------
-        other : Union[Tensor, ArrayLike]
-            The Tensor or array whose shape and datatype should be mirrored.
+    Parameters
+    ----------
+    other : Union[Tensor, ArrayLike]
+        The Tensor or array whose shape and datatype should be mirrored.
 
-        dtype : data-type, optional (default=None)
-            Override the data type of the returned Tensor with this value, or None to not override.
+    dtype : data-type, optional (default=None)
+        Override the data type of the returned Tensor with this value, or None to not override.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A Tensor of `fill_value` whose shape and data type match `other`.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> x = mg.arange(6, dtype=int)
-        >>> mg.full_like(x, 1)
-        Tensor([1, 1, 1, 1, 1, 1])
-        >>> mg.full_like(x, 0.1)
-        Tensor([0, 0, 0, 0, 0, 0])
-        >>> mg.full_like(x, 0.1, dtype=np.double)
-        Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
-        >>> mg.full_like(x, np.nan, dtype=np.double)
-        Tensor([ nan,  nan,  nan,  nan,  nan,  nan])
+        Integer-type tensors must be constant.
 
-        >>> y = mg.arange(6, dtype=np.double)
-        >>> mg.full_like(y, 0.1)
-        Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
+    Returns
+    -------
+    Tensor
+        A Tensor of `fill_value` whose shape and data type match `other`.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> x = mg.arange(6, dtype=int)
+    >>> mg.full_like(x, 1)
+    Tensor([1, 1, 1, 1, 1, 1])
+    >>> mg.full_like(x, 0.1)
+    Tensor([0, 0, 0, 0, 0, 0])
+    >>> mg.full_like(x, 0.1, dtype=np.double)
+    Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
+    >>> mg.full_like(x, np.nan, dtype=np.double)
+    Tensor([ nan,  nan,  nan,  nan,  nan,  nan])
+
+    >>> y = mg.arange(6, dtype=np.double)
+    >>> mg.full_like(y, 0.1)
+    Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
     """
     return Tensor(
         np.full_like(asarray(other), fill_value, dtype), constant=constant, copy=False,
@@ -456,43 +507,48 @@ def full_like(other, fill_value, dtype=None, constant=False):
 def arange(stop, start=0, step=1, dtype=None, constant=None):
     """ Return a Tensor with evenly-spaced values within a given interval.
 
-        Values are generated within [start, stop). Note that for non-integer steps, results may be
-        inconsistent; you are better off using `linspace` instead.
+    Values are generated within [start, stop). Note that for non-integer steps, results may be
+    inconsistent; you are better off using `linspace` instead.
 
-        Parameters
-        ----------
-        start : Real, optional, default=0
-            The start of the interval, inclusive.
+    Parameters
+    ----------
+    start : Real, optional, default=0
+        The start of the interval, inclusive.
 
-        stop : Real
-            The end of the interval, exclusive.
+    stop : Real
+        The end of the interval, exclusive.
 
-        step : Real, optional (default=1)
-            The spacing between successive values.
+    step : Real, optional (default=1)
+        The spacing between successive values.
 
-        dtype : data-type, optional (default=None)
-            The data type of the output Tensor, or None to infer from the inputs.
+    dtype : data-type, optional (default=None)
+        The data type of the output Tensor, or None to infer from the inputs.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A Tensor of evenly-spaced values in [start, end).
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> mg.arange(3)
-        Tensor([0, 1, 2])
-        >>> mg.arange(3.0, constant=True)
-        Tensor([ 0.,  1.,  2.])  # resulting tensor will not back-propagate a gradient
-        >>> mg.arange(3,7)
-        Tensor([3, 4, 5, 6])
-        >>> mg.arange(3,7,2)
-        Tensor([3, 5])
+        Integer-type tensors must be constant.
+
+    Returns
+    -------
+    Tensor
+        A Tensor of evenly-spaced values in [start, end).
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> mg.arange(3)
+    Tensor([0, 1, 2])
+    >>> mg.arange(3.0, constant=True)
+    Tensor([ 0.,  1.,  2.])  # resulting tensor will not back-propagate a gradient
+    >>> mg.arange(3,7)
+    Tensor([3, 4, 5, 6])
+    >>> mg.arange(3,7,2)
+    Tensor([3, 5])
     """
     if start > stop:
         tmp = start
@@ -501,52 +557,57 @@ def arange(stop, start=0, step=1, dtype=None, constant=None):
     return Tensor(np.arange(start, stop, step, dtype), constant=constant, copy=False)
 
 
-def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=False):
+def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=None):
     """ Return a Tensor with evenly-spaced numbers over a specified interval.
 
-        Values are generated within [start, stop], with the endpoint optionally excluded.
+    Values are generated within [start, stop], with the endpoint optionally excluded.
 
-        Parameters
-        ----------
-        start : Real
-            The starting value of the sequence, inclusive.
+    Parameters
+    ----------
+    start : Real
+        The starting value of the sequence, inclusive.
 
-        stop : Real
-            The ending value of the sequence, inclusive unless `include_endpoint` is False.
+    stop : Real
+        The ending value of the sequence, inclusive unless `include_endpoint` is False.
 
-        num : int, optional (default=50)
-            The number of values to generate. Must be non-negative.
+    num : int, optional (default=50)
+        The number of values to generate. Must be non-negative.
 
-        include_endpoint : bool, optional (default=True)
-            Whether to include the endpoint in the Tensor. Note that if False, the step size changes
-            to accommodate the sequence excluding the endpoint.
+    include_endpoint : bool, optional (default=True)
+        Whether to include the endpoint in the Tensor. Note that if False, the step size changes
+        to accommodate the sequence excluding the endpoint.
 
-        dtype : data-type, optional (default=None)
-            The data type of the output Tensor, or None to infer from the inputs.
+    dtype : data-type, optional (default=None)
+        The data type of the output Tensor, or None to infer from the inputs.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A Tensor of `num` evenly-spaced values in [start, stop] or [start, stop), depending on
-            `include_endpoint`.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        See Also
-        --------
-        arange : Similar to `linspace`, but uses a step size (instead of the
-                 number of samples).
-        logspace : Samples uniformly distributed in log space.
+        Integer-type tensors must be constant.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> mg.linspace(2.0, 3.0, num=5)
-        Tensor([ 2.  ,  2.25,  2.5 ,  2.75,  3.  ])
-        >>> mg.linspace(2.0, 3.0, num=5, endpoint=False)
-        Tensor([ 2. ,  2.2,  2.4,  2.6,  2.8])
+    Returns
+    -------
+    Tensor
+        A Tensor of `num` evenly-spaced values in [start, stop] or [start, stop), depending on
+        `include_endpoint`.
+
+    See Also
+    --------
+    arange : Similar to `linspace`, but uses a step size (instead of the
+             number of samples).
+    logspace : Samples uniformly distributed in log space.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> mg.linspace(2.0, 3.0, num=5)
+    Tensor([ 2.  ,  2.25,  2.5 ,  2.75,  3.  ])
+    >>> mg.linspace(2.0, 3.0, num=5, endpoint=False)
+    Tensor([ 2. ,  2.2,  2.4,  2.6,  2.8])
     """
     return Tensor(
         np.linspace(start, stop, num, include_endpoint, dtype=dtype),
@@ -556,62 +617,67 @@ def linspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=Fa
 
 
 def logspace(
-    start, stop, num=50, include_endpoint=True, base=10, dtype=None, constant=False
+    start, stop, num=50, include_endpoint=True, base=10, dtype=None, constant=None
 ):
     """ Return a Tensor with evenly-spaced numbers over a specified interval on a log scale.
 
-        In linear space, values are generated within [base**start, base**stop], with the endpoint
-        optionally excluded.
+    In linear space, values are generated within [base**start, base**stop], with the endpoint
+    optionally excluded.
 
-        Parameters
-        ----------
-        start : Real
-            The starting value of the sequence, inclusive; start at `base ** start`.
+    Parameters
+    ----------
+    start : Real
+        The starting value of the sequence, inclusive; start at `base ** start`.
 
-        stop : Real
-            The ending value of the sequence, inclusive unless `include_endpoint` is False; end at
-            `base ** stop`.
+    stop : Real
+        The ending value of the sequence, inclusive unless `include_endpoint` is False; end at
+        `base ** stop`.
 
-        num : int, optional (default=50)
-            The number of values to generate. Must be non-negative.
+    num : int, optional (default=50)
+        The number of values to generate. Must be non-negative.
 
-        include_endpoint : bool, optional (default=True)
-            Whether to include the endpoint in the Tensor. Note that if False, the step size changes
-            to accommodate the sequence excluding the endpoint.
+    include_endpoint : bool, optional (default=True)
+        Whether to include the endpoint in the Tensor. Note that if False, the step size changes
+        to accommodate the sequence excluding the endpoint.
 
-        base : Real, optional (default=10)
-            The base of the log space.
+    base : Real, optional (default=10)
+        The base of the log space.
 
-        dtype : data-type, optional (default=None)
-            The data type of the output Tensor, or None to infer from the inputs.
+    dtype : data-type, optional (default=None)
+        The data type of the output Tensor, or None to infer from the inputs.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        See Also
-        --------
-        arange : Similar to linspace, with the step size specified instead of the
-                 number of samples. Note that, when used with a float endpoint, the
-                 endpoint may or may not be included.
-        linspace : Similar to logspace, but with the samples uniformly distributed
-                   in linear space, instead of log space.
-        geomspace : Similar to logspace, but with endpoints specified directly.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> mg.logspace(2.0, 3.0, num=4)
-        Tensor([  100.        ,   215.443469  ,   464.15888336,  1000.        ])
-        >>> mg.logspace(2.0, 3.0, num=4, endpoint=False)
-        Tensor([ 100.        ,  177.827941  ,  316.22776602,  562.34132519])
-        >>> mg.logspace(2.0, 3.0, num=4, base=2.0)
-        Tensor([ 4.        ,  5.0396842 ,  6.34960421,  8.        ])
+        Integer-type tensors must be constant.
 
-        Returns
-        -------
-        Tensor
-            A Tensor of `num` evenly-spaced values in the log interval [base**start, base**stop].
+    See Also
+    --------
+    arange : Similar to linspace, with the step size specified instead of the
+             number of samples. Note that, when used with a float endpoint, the
+             endpoint may or may not be included.
+    linspace : Similar to logspace, but with the samples uniformly distributed
+               in linear space, instead of log space.
+    geomspace : Similar to logspace, but with endpoints specified directly.
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> mg.logspace(2.0, 3.0, num=4)
+    Tensor([  100.        ,   215.443469  ,   464.15888336,  1000.        ])
+    >>> mg.logspace(2.0, 3.0, num=4, endpoint=False)
+    Tensor([ 100.        ,  177.827941  ,  316.22776602,  562.34132519])
+    >>> mg.logspace(2.0, 3.0, num=4, base=2.0)
+    Tensor([ 4.        ,  5.0396842 ,  6.34960421,  8.        ])
+
+    Returns
+    -------
+    Tensor
+        A Tensor of `num` evenly-spaced values in the log interval [base**start, base**stop].
     """
     return Tensor(
         np.logspace(start, stop, num, include_endpoint, base, dtype),
@@ -620,73 +686,78 @@ def logspace(
     )
 
 
-def geomspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=False):
+def geomspace(start, stop, num=50, include_endpoint=True, dtype=None, constant=None):
     """ Return a Tensor with evenly-spaced values in a geometric progression.
 
-        Each output sample is a constant multiple of the previous output.
+    Each output sample is a constant multiple of the previous output.
 
-        Parameters
-        ----------
-        start : Real
-            The starting value of the output.
+    Parameters
+    ----------
+    start : Real
+        The starting value of the output.
 
-        stop : Real
-            The ending value of the sequence, inclusive unless `include_endpoint` is false.
+    stop : Real
+        The ending value of the sequence, inclusive unless `include_endpoint` is false.
 
-        num : int, optional (default=50)
-            The number of values to generate. Must be non-negative.
+    num : int, optional (default=50)
+        The number of values to generate. Must be non-negative.
 
-        include_endpoint : bool, optional (default=True)
-            Whether to include the endpoint in the Tensor. Note that if False, the step size changes
-            to accommodate the sequence excluding the endpoint.
+    include_endpoint : bool, optional (default=True)
+        Whether to include the endpoint in the Tensor. Note that if False, the step size changes
+        to accommodate the sequence excluding the endpoint.
 
-        dtype : data-type, optional (default=None)
-            The data type of the output Tensor, or None to infer from the inputs.
+    dtype : data-type, optional (default=None)
+        The data type of the output Tensor, or None to infer from the inputs.
 
-        constant : bool, optional (default=False)
-            If ``True``, the returned tensor is a constant (it
-            does not back-propagate a gradient)
+    constant : Optional[bool]
+        If ``True``, this tensor is a constant, and thus does not facilitate
+        back propagation.
 
-        Returns
-        -------
-        Tensor
-            A Tensor of `num` samples, evenly-spaced in a geometric progression.
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
 
-        See Also
-        --------
-        logspace : Similar to geomspace, but with endpoints specified using log
-                   and base.
-        linspace : Similar to geomspace, but with arithmetic instead of geometric
-                   progression.
-        arange : Similar to linspace, with the step size specified instead of the
-                 number of samples.
+        Integer-type tensors must be constant.
 
-        Examples
-        --------
-        >>> import mygrad as mg
-        >>> import numpy as np
-        >>> mg.geomspace(1, 1000, num=4)
-        Tensor([    1.,    10.,   100.,  1000.])
-        >>> mg.geomspace(1, 1000, num=3, endpoint=False)
-        Tensor([   1.,   10.,  100.])
-        >>> mg.geomspace(1, 1000, num=4, endpoint=False)
-        Tensor([   1.        ,    5.62341325,   31.6227766 ,  177.827941  ])
-        >>> mg.geomspace(1, 256, num=9)
-        Tensor([   1.,    2.,    4.,    8.,   16.,   32.,   64.,  128.,  256.])
+    Returns
+    -------
+    Tensor
+        A Tensor of `num` samples, evenly-spaced in a geometric progression.
 
-        Note that the above may not produce exact integers:
+    See Also
+    --------
+    logspace : Similar to geomspace, but with endpoints specified using log
+               and base.
+    linspace : Similar to geomspace, but with arithmetic instead of geometric
+               progression.
+    arange : Similar to linspace, with the step size specified instead of the
+             number of samples.
 
-        >>> mg.geomspace(1, 256, num=9, dtype=int)
-        Tensor([  1,   2,   4,   7,  16,  32,  63, 127, 256])
-        >>> np.around(mg.geomspace(1, 256, num=9).data).astype(int)
-        array([  1,   2,   4,   8,  16,  32,  64, 128, 256])
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> import numpy as np
+    >>> mg.geomspace(1, 1000, num=4)
+    Tensor([    1.,    10.,   100.,  1000.])
+    >>> mg.geomspace(1, 1000, num=3, endpoint=False)
+    Tensor([   1.,   10.,  100.])
+    >>> mg.geomspace(1, 1000, num=4, endpoint=False)
+    Tensor([   1.        ,    5.62341325,   31.6227766 ,  177.827941  ])
+    >>> mg.geomspace(1, 256, num=9)
+    Tensor([   1.,    2.,    4.,    8.,   16.,   32.,   64.,  128.,  256.])
 
-        Negative, decreasing, and complex inputs are allowed:
+    Note that the above may not produce exact integers:
 
-        >>> mg.geomspace(1000, 1, num=4)
-        Tensor([ 1000.,   100.,    10.,     1.])
-        >>> mg.geomspace(-1000, -1, num=4)
-        Tensor([-1000.,  -100.,   -10.,    -1.])
+    >>> mg.geomspace(1, 256, num=9, dtype=int)
+    Tensor([  1,   2,   4,   7,  16,  32,  63, 127, 256])
+    >>> np.around(mg.geomspace(1, 256, num=9).data).astype(int)
+    array([  1,   2,   4,   8,  16,  32,  64, 128, 256])
+
+    Negative, decreasing, and complex inputs are allowed:
+
+    >>> mg.geomspace(1000, 1, num=4)
+    Tensor([ 1000.,   100.,    10.,     1.])
+    >>> mg.geomspace(-1000, -1, num=4)
+    Tensor([-1000.,  -100.,   -10.,    -1.])
     """
     return Tensor(
         np.geomspace(start, stop, num, include_endpoint, dtype),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,4 +6,4 @@ import mygrad as mg
 
 
 def is_float_arr(arr: Union[np.ndarray, mg.Tensor]) -> bool:
-    return issubclass(arr.dtype.type, np.integer)
+    return issubclass(arr.dtype.type, np.floating)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+from typing import Union
+
+import numpy as np
+
+import mygrad as mg
+
+
+def is_float_arr(arr: Union[np.ndarray, mg.Tensor]) -> bool:
+    return issubclass(arr.dtype.type, np.integer)

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -80,7 +80,7 @@ class VerboseTensor(Tensor):
     def __repr__(self):
         repr_ = repr(self.data).replace("array", "Tensor").replace("\n", "\n ")
         replacement = (
-            f", constant={self.constant}, writeable={self.data.flags.writeable}"
+            f", constant={self._constant}, writeable={self.data.flags.writeable}"
         )
         if self.grad is not None:
             replacement += f", grad={repr(self.grad)}"
@@ -228,6 +228,9 @@ def tensors(
     x.flags.writeable = not read_only
 
     constant = draw(constant) if isinstance(constant, st.SearchStrategy) else constant
+
+    if np.issubdtype(x.dtype, np.integer):
+        constant = True
 
     tensor = VerboseTensor(x, constant=constant, copy=False, ndmin=ndmin)
     if isinstance(include_grad, st.SearchStrategy):

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -724,3 +724,11 @@ def arbitrary_indices(draw, shape: Tuple[int]):
 
     out_ind = tuple(i[1] for i in index)
     return out_ind
+
+
+@st.composite
+def valid_constant_arg(draw, dtype: np.dtype) -> st.SearchStrategy[Union[None, bool]]:
+    if issubclass(dtype.type, np.floating):
+        return draw(st.none() | st.booleans())
+    else:
+        return draw(st.sampled_from([None, True]))

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "everything_except",
     "valid_shapes",
     "valid_axes",
+    "valid_constant_arg",
     "tensors",
 ]
 

--- a/tests/custom_strategies/test_strategies.py
+++ b/tests/custom_strategies/test_strategies.py
@@ -204,7 +204,7 @@ def test_arbitrary_indices_strategy(a, data):
 @pytest.mark.parametrize("constant", [st.booleans(), None])
 def test_tensors_handles_constant_strat(constant):
     constants = []
-    kwargs = dict(dtype=np.int8, shape=(2, 3))
+    kwargs = dict(dtype=np.float32, shape=(2, 3))
     if constant is not None:
         kwargs["constant"] = constant
 
@@ -220,7 +220,7 @@ def test_tensors_handles_constant_strat(constant):
 @pytest.mark.parametrize("constant", [True, False])
 @given(data=st.data())
 def test_tensors_static_constant(constant: bool, data: st.DataObject):
-    tensor = data.draw(tensors(np.int8, (2, 3), constant=constant), label="tensor")
+    tensor = data.draw(tensors(np.float32, (2, 3), constant=constant), label="tensor")
     assert isinstance(tensor, Tensor)
     assert tensor.constant is constant
     assert tensor.grad is None

--- a/tests/linalg/test_einsum.py
+++ b/tests/linalg/test_einsum.py
@@ -281,7 +281,7 @@ def test_redundant_args():
     was added such that einsum will only compute the gradient for such an entry
     once and scale it accordingly.
     """
-    a = mg.arange(4).reshape(2, 2)
+    a = mg.arange(4.0).reshape(2, 2)
     a_copy = copy(a)
 
     # check standard summation
@@ -294,7 +294,7 @@ def test_redundant_args():
     o.sum().backward()
     assert_allclose(a.grad, a_copy.grad)
 
-    a = Tensor(np.arange(4).reshape(2, 2))
+    a = Tensor(np.arange(4.0).reshape(2, 2))
     a_copy = copy(a)
 
     # check standard summation using alt signature
@@ -307,7 +307,7 @@ def test_redundant_args():
     o.sum().backward()
     assert_allclose(a.grad, a_copy.grad)
 
-    a = Tensor(np.arange(4).reshape(2, 2))
+    a = Tensor(np.arange(4.0).reshape(2, 2))
     a_copy = copy(a)
 
     # check matmul (no redundant indices)
@@ -319,7 +319,7 @@ def test_redundant_args():
     o.sum().backward()
     assert_allclose(a.grad, a_copy.grad)
 
-    a = Tensor(np.arange(4).reshape(2, 2))
+    a = Tensor(np.arange(4.0).reshape(2, 2))
     a_copy = copy(a)
 
     # check traces
@@ -332,10 +332,10 @@ def test_redundant_args():
     o.sum().backward()
     assert_allclose(a.grad, a_copy.grad)
 
-    a = Tensor(np.arange(4).reshape(2, 2))
+    a = Tensor(np.arange(4.0).reshape(2, 2))
     a_copy = copy(a)
 
-    b = Tensor(-1 * np.arange(2).reshape(2, 1))
+    b = Tensor(-1 * np.arange(2.0).reshape(2, 1))
     b_copy = copy(b)
 
     # check broadcasting and multiply-redundant input tensors

--- a/tests/math/sequence/test_sequential_funcs.py
+++ b/tests/math/sequence/test_sequential_funcs.py
@@ -210,17 +210,28 @@ def test_custom_var_fwd():
     pass
 
 
+# test keepdims=True/False explicitly to deal with coverage issues
 @backprop_test_factory(
     mygrad_func=var,
     true_func=_var,
     num_arrays=1,
-    kwargs=dict(
-        axis=partial(axis_arg, min_dim=1), keepdims=keepdims_arg, ddof=ddof_arg
-    ),
+    kwargs=dict(axis=partial(axis_arg, min_dim=1), keepdims=False, ddof=ddof_arg),
     vary_each_element=True,
     index_to_bnds={0: (-10, 10)},
 )
-def test_var_bkwd():
+def test_var_bkwd_without_keepdims():
+    pass
+
+
+@backprop_test_factory(
+    mygrad_func=var,
+    true_func=_var,
+    num_arrays=1,
+    kwargs=dict(axis=partial(axis_arg, min_dim=1), keepdims=True, ddof=ddof_arg),
+    vary_each_element=True,
+    index_to_bnds={0: (-10, 10)},
+)
+def test_var_bkwd_with_keepdims():
     pass
 
 

--- a/tests/nnet/activations/test_softmax.py
+++ b/tests/nnet/activations/test_softmax.py
@@ -96,50 +96,6 @@ def test_logsoftmax_bkwd():
     pass
 
 
-# old tests; ensures backwards compatibility at least...
-
-
-def test_static_softmax_integer():
-    # reuse the test cases from below with integer arrays
-    skew = np.array([0.87566484, 0.53596079, 0.85693981, 0.09526036])
-    x = Tensor([0, 1, 2, 3])
-
-    f = (softmax(x, constant=False) * skew).sum()
-
-    out = np.array(0.33911235096116465)
-    assert_allclose(actual=f.data, desired=out)
-
-    f.backward()
-    dx = np.array([0.01720112, 0.01715422, 0.12266443, -0.15701977])
-
-    assert_allclose(x.grad, dx, atol=1e-5, rtol=1e-5)
-
-    skew = np.array(
-        [
-            [0.87566484, 0.53596079, 0.85693981, 0.09526036],
-            [0.32024455, 0.81532148, 0.2480434, 0.85119342],
-            [0.57943085, 0.33958252, 0.95864464, 0.22881712],
-        ]
-    )
-    x = Tensor([[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11]])
-
-    f = (softmax(x, constant=False) * skew).sum()
-
-    out = np.array(1.449875865467131)
-    assert_allclose(actual=f.data, desired=out)
-
-    f.backward()
-    dx = np.array(
-        [
-            [0.01720112, 0.01715422, 0.12266443, -0.15701977],
-            [-0.01179518, 0.01108053, -0.10425844, 0.10497309],
-            [0.00502799, -0.00723393, 0.12698131, -0.12477536],
-        ]
-    )
-
-    assert_allclose(x.grad, dx, atol=1e-5, rtol=1e-5)
-
-
 def test_static_softmax1d():
     # Verified against theano.tensor.softmax
 

--- a/tests/nnet/initializers/test_constant.py
+++ b/tests/nnet/initializers/test_constant.py
@@ -1,27 +1,34 @@
-from hypothesis import assume, given
-import hypothesis.strategies as st
 import hypothesis.extra.numpy as hnp
-
+import hypothesis.strategies as st
 import numpy as np
+from hypothesis import assume, given
 
 from mygrad import Tensor
 from mygrad.nnet.initializers import constant as constant_initializer
+from tests.custom_strategies import valid_constant_arg
 
 
 @given(
     array=hnp.arrays(
-        dtype=hnp.integer_dtypes() | hnp.unsigned_integer_dtypes() | hnp.floating_dtypes(),
+        dtype=hnp.integer_dtypes()
+        | hnp.unsigned_integer_dtypes()
+        | hnp.floating_dtypes(),
         shape=hnp.array_shapes(),
     ),
-    constant=st.booleans(),
+    data=st.data(),
 )
-def test_constant_initializer(array, constant):
-    value = array.reshape(-1)[0]  # let hypothesis do all the heavy lifting picking an acceptable value for the dtype
+def test_constant_initializer(array, data: st.DataObject):
+
+    value = array.reshape(-1)[
+        0
+    ]  # let hypothesis do all the heavy lifting picking an acceptable value for the dtype
     assume(not np.isnan(value))
-    tensor = constant_initializer(array.shape, value=value, dtype=array.dtype, constant=constant)
+    constant = data.draw(valid_constant_arg(array.dtype), label="constant")
+    tensor = constant_initializer(
+        array.shape, value=value, dtype=array.dtype, constant=constant
+    )
 
     assert isinstance(tensor, Tensor)
     assert np.allclose(tensor.data, value, equal_nan=True)
     assert tensor.data.shape == array.shape
     assert tensor.data.dtype == array.dtype
-

--- a/tests/nnet/layers/test_maxpool.py
+++ b/tests/nnet/layers/test_maxpool.py
@@ -23,7 +23,7 @@ def text_constant():
             ],
         ]
     )
-    x = Tensor(x)
+    x = Tensor(x, dtype="float32")
     pool = (3,)
     stride = (1,)
     assert max_pool(x, pool, stride, constant=True).constant is True
@@ -47,7 +47,7 @@ def test_1d_case():
             ],
         ]
     )
-    x = Tensor(x)
+    x = Tensor(x, dtype="float32")
     pool = (3,)
     stride = (1,)
     out = max_pool(x, pool, stride)
@@ -100,7 +100,7 @@ def test_2d_case():
             ],
         ]
     )
-    x = Tensor(x)
+    x = Tensor(x, dtype="float32")
     pool = (2, 3)
     stride = (2, 1)
     out = max_pool(x, pool, stride)
@@ -148,7 +148,7 @@ def test_3d_case():
             ],
         ]
     )
-    x = Tensor(x)
+    x = Tensor(x, dtype="float32")
     pool = (2, 2, 2)
     stride = (1, 1, 2)
     out = max_pool(x, pool, stride)
@@ -179,7 +179,7 @@ def test_3d_case():
 
 
 def test_bad_max_shapes():
-    x = Tensor(np.zeros((1, 2, 2, 2)))
+    x = Tensor(np.zeros((1, 2, 2, 2)), dtype="float32")
     with raises(ValueError):
         max_pool(x, (3,) * 3, (1,) * 3)  # large filter
 

--- a/tests/tensor_base/test_astype.py
+++ b/tests/tensor_base/test_astype.py
@@ -6,7 +6,6 @@ from hypothesis import given, settings
 from numpy.testing import assert_array_equal
 
 from mygrad import Tensor
-from tests import is_float_arr
 from tests.custom_strategies import tensors, valid_constant_arg
 
 real_types = (

--- a/tests/tensor_base/test_astype.py
+++ b/tests/tensor_base/test_astype.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
@@ -8,6 +6,8 @@ from hypothesis import given, settings
 from numpy.testing import assert_array_equal
 
 from mygrad import Tensor
+from tests import is_float_arr
+from tests.custom_strategies import tensors, valid_constant_arg
 
 real_types = (
     hnp.integer_dtypes() | hnp.unsigned_integer_dtypes() | hnp.floating_dtypes()
@@ -15,24 +15,22 @@ real_types = (
 
 
 @given(
-    tensor=st.tuples(
-        hnp.arrays(shape=hnp.array_shapes(), dtype=real_types), st.booleans(),
-    ).map(lambda x: Tensor(x[0], constant=x[1])),
-    dest_type=real_types,
-    constant=st.booleans() | st.none(),
+    tensor=tensors(dtype=real_types), dest_type=real_types, data=st.data(),
 )
-def test_astype(tensor: Tensor, dest_type: type, constant: Optional[bool]):
-    tensor = tensor * 1  # give tensor a creator
+def test_astype(tensor: Tensor, dest_type: np.dtype, data: st.DataObject):
+    tensor = +tensor  # give tensor a creator
+    constant = data.draw(valid_constant_arg(dest_type), label="constant")
     new_tensor = tensor.astype(dest_type, constant=constant)
 
-    assert new_tensor.constant is (tensor.constant if constant is None else constant)
+    expected_tensor = Tensor(tensor, dtype=dest_type, constant=constant)
+
+    assert new_tensor.constant is expected_tensor.constant
     assert tensor.creator is not None
     assert new_tensor.creator is None
-    assert new_tensor.dtype is dest_type
+    assert new_tensor.dtype == dest_type
     assert new_tensor.shape == tensor.shape
-
-    if new_tensor.dtype is tensor.dtype:
-        assert_array_equal(new_tensor.data, tensor.data)
+    assert new_tensor.data is not tensor.data
+    assert_array_equal(new_tensor.data, expected_tensor.data)
 
 
 @settings(max_examples=30)

--- a/tests/tensor_base/test_dtype_init.py
+++ b/tests/tensor_base/test_dtype_init.py
@@ -1,0 +1,84 @@
+import hypothesis.extra.numpy as hnp
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+from hypothesis import given
+
+import mygrad as mg
+from tests.custom_strategies import tensors
+from tests.utils import does_not_raise
+
+
+def arrays_or_tensors(*args, **kwargs):
+    return hnp.arrays(*args, **kwargs) | tensors(*args, **kwargs)
+
+
+generic_data = st.sampled_from([0, 0.0, [0], [0.0]]) | arrays_or_tensors(
+    dtype=hnp.floating_dtypes() | hnp.integer_dtypes(),
+    shape=hnp.array_shapes(min_dims=0, min_side=0),
+)
+
+integer_data = st.sampled_from([0, [0]]) | arrays_or_tensors(
+    dtype=hnp.integer_dtypes(), shape=hnp.array_shapes(min_dims=0, min_side=0),
+)
+
+float_data = st.sampled_from([0.0, [0.0]]) | arrays_or_tensors(
+    dtype=hnp.floating_dtypes(), shape=hnp.array_shapes(min_dims=0, min_side=0),
+)
+
+integer_dtypes = st.sampled_from([int, "int32"]) | hnp.integer_dtypes()
+float_dtypes = st.sampled_from([float, "float32"]) | hnp.floating_dtypes()
+
+
+@given(
+    data=st.data(),
+    dtype=st.none() | integer_dtypes,
+    constant=st.none() | st.booleans(),
+    copy=st.booleans(),
+    ndmin=st.integers(0, 3),
+)
+def test_integer_dtype_behavior(
+    data: st.DataObject, dtype, constant, copy: bool, ndmin: int
+):
+    """Tests scenarios where tensor.dtype will ultimately be
+    a integer dtype"""
+
+    data_strat = integer_data if dtype is None else generic_data
+    arr_data = data.draw(data_strat, label="arr_data")
+
+    with (
+        pytest.raises(ValueError) if constant is False else does_not_raise()
+    ) as exec_info:
+        # Setting `constant=False` for an integer-type tensor should raise
+        tensor = mg.Tensor(
+            arr_data, dtype=dtype, constant=constant, copy=copy, ndmin=ndmin
+        )
+
+    if exec_info is None:  # did not raise
+        assert tensor.constant is True
+        assert np.issubdtype(tensor.dtype, np.integer)
+
+
+@given(
+    data=st.data(),
+    dtype=st.none() | float_dtypes,
+    constant=st.none() | st.booleans(),
+    copy=st.booleans(),
+    ndmin=st.integers(0, 3),
+)
+def test_float_dtype_behavior(
+    data: st.DataObject, dtype, constant, copy: bool, ndmin: int
+):
+    """Tests scenarios where tensor.dtype will ultimately be
+    a float dtype"""
+
+    data_strat = float_data if dtype is None else generic_data
+    arr_data = data.draw(data_strat, label="arr_data")
+    tensor = mg.Tensor(arr_data, dtype=dtype, constant=constant, copy=copy, ndmin=ndmin)
+
+    if constant is None:
+        assert tensor.constant is False
+    else:
+        assert tensor.constant is constant
+
+    assert np.issubdtype(tensor.dtype, np.floating)

--- a/tests/tensor_base/test_op_wrapper.py
+++ b/tests/tensor_base/test_op_wrapper.py
@@ -25,8 +25,8 @@ def dummy(a, b, constant=False):
 @pytest.mark.parametrize("op_const", [True, False])
 def test_constant_arg(x_const: bool, y_const: bool, op_const: bool):
     """ test that the `constant` arg works as intended in Tensor._op"""
-    x = Tensor(1, constant=x_const)
-    y = Tensor(1, constant=y_const)
+    x = Tensor(1.0, constant=x_const)
+    y = Tensor(1.0, constant=y_const)
     out = dummy(x, y, constant=op_const)
     assert out.constant is op_const or (x_const and y_const)
     assert set(i() for i in x._ops) == {out.creator}

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -14,8 +14,13 @@ from mygrad.errors import InvalidBackprop, InvalidGradient
 from mygrad.linalg.ops import MatMul
 from mygrad.math.arithmetic.ops import Add, Divide, Multiply, Negative, Power, Subtract
 from mygrad.operation_base import Operation
-from tests.custom_strategies import everything_except, tensors
+from tests.custom_strategies import everything_except, tensors, valid_constant_arg
 from tests.utils import does_not_raise
+
+
+def test_simple_default_constant_behavior():
+    assert Tensor(1).constant is True
+    assert Tensor(1.0).constant is False
 
 
 @pytest.mark.parametrize(
@@ -35,7 +40,7 @@ def test_input_type_checking(data, constant, creator):
         Tensor(data, constant=constant, _creator=creator)
 
 
-@given(constant=everything_except(bool))
+@given(constant=everything_except((bool, type(None))))
 def test_input_constant_checking(constant):
     with raises(TypeError):
         Tensor(1.0, constant=constant)
@@ -162,7 +167,7 @@ def test_repr(tensor, repr_):
 
 @given(constant=st.booleans())
 def test_invalid_gradient_raises(constant: bool):
-    x = Tensor(3, constant=constant) * 2
+    x = Tensor(3.0, constant=constant) * 2
     with (pytest.raises(InvalidGradient) if not constant else does_not_raise()):
         x.backward("bad")
 
@@ -219,17 +224,15 @@ def test_init_data():
         dtype=hnp.floating_dtypes(), shape=hnp.array_shapes(min_side=1, min_dims=1)
     ),
     as_tensor=st.booleans(),
+    constant=st.booleans(),
 )
-def test_copy_on_init_behavior(arr: np.ndarray, as_tensor: bool):
+def test_tensor_copy_on_init_mirrors_array(
+    arr: np.ndarray, as_tensor: bool, constant: bool
+):
     x = Tensor(arr, copy=False) if as_tensor else arr
-    t_no_constant = Tensor(x)
-    assert not np.shares_memory(t_no_constant, arr)
-
-    t_constant = Tensor(x, constant=True)
-    assert np.shares_memory(t_constant, arr)
-
-    t_not_constant = Tensor(x, constant=False)
-    assert not np.shares_memory(t_not_constant, arr)
+    tensor = Tensor(x, constant=constant)
+    array = np.array(arr)
+    assert np.shares_memory(tensor, arr) is np.shares_memory(array, arr)
 
 
 @given(
@@ -284,14 +287,13 @@ dtype_strat_numpy = st.sampled_from(
 @given(
     data=st.data(),
     creator=st.sampled_from((None, op)),
-    constant=st.booleans(),
     dtype=dtype_strat,
     numpy_dtype=dtype_strat_numpy,
     ndmin=st.integers(0, 10),
     copy=st.none() | st.booleans(),
 )
 def test_init_params(
-    data, creator, constant, dtype, numpy_dtype, ndmin: int, copy: Optional[bool],
+    data, creator, dtype, numpy_dtype, ndmin: int, copy: Optional[bool],
 ):
     """Check for bad combinations of init parameters leading to unexpected behavior"""
     elements = (
@@ -308,16 +310,21 @@ def test_init_params(
         hnp.arrays(**array_strat_args) | tensors(**array_strat_args), label="a",
     )
 
+    arr = np.array(a, dtype=dtype, ndmin=ndmin)
+
+    constant = data.draw(valid_constant_arg(arr.dtype), label="constant")
+
     tensor = Tensor(
         a, _creator=creator, constant=constant, dtype=dtype, ndmin=ndmin, copy=copy,
     )
 
-    a = np.array(a, dtype=dtype, ndmin=ndmin)
+    if constant is None:
+        constant = issubclass(tensor.dtype.type, np.integer)
 
     assert tensor.creator is creator
     assert tensor.constant is constant
-    assert tensor.dtype is a.dtype
-    assert_equal(tensor.data, a)
+    assert tensor.dtype is arr.dtype
+    assert_equal(tensor.data, arr)
     assert tensor.grad is None
     assert tensor.base is None
     assert tensor.ndim >= ndmin

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -25,6 +25,8 @@ from tests.utils import does_not_raise
         np.array(None, dtype="O"),
         np.array([[0], [0, 0]], dtype="O"),
         np.array(1, dtype="O"),
+        0j,
+        np.array(1, dtype=np.complex),
     ],
 )
 @given(constant=st.booleans(), creator=st.none() | st.just(MatMul()))

--- a/tests/tensor_ops/test_getitem.py
+++ b/tests/tensor_ops/test_getitem.py
@@ -15,7 +15,7 @@ from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
 def test_getitem():
-    x = Tensor([1, 2, 3])
+    x = Tensor([1.0, 2.0, 3.0])
     a, b, c = x
     f = 2 * a + 3 * b + 4 * c
     f.backward()

--- a/tests/tensor_ops/test_iter.py
+++ b/tests/tensor_ops/test_iter.py
@@ -20,7 +20,7 @@ def _sum(x, constant=False):
         if not isinstance(out, Tensor):
             # Hack to deal with summing over an empty tensor.
             # `sum(Tensor([]))` returns 0, which is fine
-            out = Tensor(out, constant=constant or x.constant)
+            out = Tensor(float(out), constant=constant or x.constant)
         if constant:
             out._constant = constant
     else:

--- a/tests/test_no_autodiff.py
+++ b/tests/test_no_autodiff.py
@@ -17,6 +17,14 @@ def test_graph_tracking_is_on_by_default():
     assert _tracking.TRACK_GRAPH is True
 
 
+def test_no_autodiff_doesnt_restrict_tensor_type():
+    with no_autodiff:
+        x = Tensor(1.0, dtype=np.complex64)
+
+    # non-floats should be constant
+    assert x.constant is True
+
+
 @pytest.mark.usefixtures("seal_graph_tracking")
 @given(x=tensors(shape=(1,), elements=st.floats(-100, 100)), constant=st.booleans())
 def test_no_autodiff_context_manager(x: Tensor, constant: bool):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
@@ -5,7 +7,16 @@ import pytest
 from hypothesis import given
 from numpy.testing import assert_allclose
 
-from mygrad.random import *
+from mygrad.random import (
+    rand,
+    randint,
+    randn,
+    random,
+    random_sample,
+    ranf,
+    sample,
+    seed,
+)
 
 shape_functions = [
     (np.random.sample, sample),
@@ -15,27 +26,31 @@ shape_functions = [
 ]
 
 
-@given(shape=hnp.array_shapes(max_side=4, max_dims=5))
-@pytest.mark.parametrize("np_function,mg_function", shape_functions)
-def test_random_shape_funcs(np_function, mg_function, shape):
+@given(shape=hnp.array_shapes(max_side=4, max_dims=5), constant=st.booleans())
+@pytest.mark.parametrize("np_function, mg_function", shape_functions)
+def test_random_shape_funcs(
+    np_function: Callable, mg_function: Callable, shape, constant: bool
+):
     np.random.seed(0)
     arr = np_function(shape)
     seed(0)
-    tens = mg_function(shape)
+    tens = mg_function(shape, constant=constant)
     assert_allclose(arr, tens.data)
+    assert tens.constant is constant
 
 
 unpacked_shape_functions = [(np.random.rand, rand), (np.random.randn, randn)]
 
 
-@given(shape=hnp.array_shapes(max_side=4, max_dims=5))
+@given(shape=hnp.array_shapes(max_side=4, max_dims=5), constant=st.booleans())
 @pytest.mark.parametrize("np_function,mg_function", unpacked_shape_functions)
-def test_unpacked_shape_funcs(np_function, mg_function, shape):
+def test_unpacked_shape_funcs(np_function, mg_function, shape, constant: bool):
     np.random.seed(0)
     arr = np_function(*shape)
     seed(0)
-    tens = mg_function(*shape)
+    tens = mg_function(*shape, constant=constant)
     assert_allclose(arr, tens.data)
+    assert tens.constant is constant
 
 
 bound_shape_functions = [
@@ -48,7 +63,7 @@ bound_shape_functions = [
     m=st.integers(-10000, 10000),
     n=st.integers(-10000, 10000),
 )
-@pytest.mark.parametrize("np_function,mg_function", bound_shape_functions)
+@pytest.mark.parametrize("np_function, mg_function", bound_shape_functions)
 def test_bound_shape_functions(np_function, mg_function, m, n, shape):
     if m > n:
         m, n = n, m

--- a/tests/test_tensor_creation.py
+++ b/tests/test_tensor_creation.py
@@ -78,6 +78,22 @@ def test_tensor_creation_matches_array_creation(
     )
 
 
+def test_simple_as_tensor():
+    arr = np.array(1, dtype=np.int8)
+    x = astensor(arr)
+    assert x.constant is True
+    assert x.data.dtype == np.int8
+    assert x.data.item() == 1
+    assert x.data is arr
+
+    arr = np.array(1.0, dtype=np.float32)
+    x = astensor(arr)
+    assert x.constant is False
+    assert x.data.dtype == np.float32
+    assert x.data.item() == 1.0
+    assert x.data is arr
+
+
 @given(
     t=tensors(dtype=hnp.floating_dtypes(), include_grad=st.booleans()),
     in_graph=st.booleans(),

--- a/tests/test_tensor_creation.py
+++ b/tests/test_tensor_creation.py
@@ -34,7 +34,7 @@ def check_tensor_array(tensor, array, constant):
     assert tensor.constant is constant
 
 
-@given(constant=st.booleans(), dtype=st.sampled_from((np.int32, np.float64)))
+@given(constant=st.booleans(), dtype=st.sampled_from((np.float32, np.float64)))
 def test_all_tensor_creation(constant, dtype):
     x = np.array([1, 2, 3])
 
@@ -160,12 +160,12 @@ def test_astensor_with_incompat_constant_still_passes_array_ref(
 
     t2 = astensor(t, constant=not t.constant)
     assert t2 is not t
-    assert (t2.data is t.data) is t2.constant  # data copied if constant=False
+    assert t2.data is t.data
     assert t2.creator is None
 
     t3 = astensor(t, dtype=t.dtype, constant=not t.constant)
     assert t3 is not t
-    assert (t3.data is t.data) is t3.constant  # data copied if constant=False
+    assert t3.data is t.data
     assert t3.creator is None
 
 

--- a/tests/test_tensor_manip.py
+++ b/tests/test_tensor_manip.py
@@ -73,7 +73,7 @@ def test_transpose(x, data):
 
 
 def test_transpose_property():
-    dat = np.arange(6).reshape(2, 3)
+    dat = np.arange(6.0).reshape(2, 3)
     x = Tensor(dat)
     f = x.T
     f.backward(dat.T)
@@ -83,7 +83,7 @@ def test_transpose_property():
 
 
 def test_transpose_method():
-    dat = np.arange(24).reshape(2, 3, 4)
+    dat = np.arange(24.0).reshape(2, 3, 4)
 
     for axes in permutations(range(3)):
         # passing tuple of integers

--- a/tests/test_view_semantics.py
+++ b/tests/test_view_semantics.py
@@ -94,8 +94,8 @@ def test_simple_view_becomes_disconnected_from_base_via_clear_graph2():
 
 @pytest.mark.parametrize("constant", [True, False])
 def test_tensor_base_matches_ndarray_base(constant: bool):
-    tens = mg.arange(10, constant=constant)
-    arr = np.arange(10)
+    tens = mg.arange(10.0, constant=constant)
+    arr = np.arange(10.0)
 
     assert tens.base is None
     assert arr.base is None

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from hypothesis import given
 from numpy.testing import assert_allclose
 
+from tests import is_float_arr
 from tests.custom_strategies import tensors
 from tests.utils import flags_to_dict
 from tests.utils.numerical_gradient import (
@@ -13,6 +14,12 @@ from tests.utils.numerical_gradient import (
     numerical_gradient,
     numerical_gradient_full,
 )
+
+
+def test_is_float_arr():
+    assert is_float_arr(np.array(1)) is False
+    assert is_float_arr(np.array([1.0j])) is False
+    assert is_float_arr(np.array(1.0)) is True
 
 
 def unary_func(x):


### PR DESCRIPTION
Derivatives involving integer-valued tensors are typically ill-defined, and in MyGrad 1.X they
were generally just wrong. Now integer-valued tensors can only be involved in computational
graphs as constants.

An integer-valued tensor will default to being a constant:

```python
>>> Tensor(1).constant
True
```

Trying to make an integer-valued tensor a non-constant raises

```python
>>> Tensor(1, constant=False)
ValueError: Integer-valued tensors must be treated as constants.
```