### PR TITLE
Make tensor.backward() support broadcasting and type-casting

### DIFF
--- a/src/mygrad/_utils/__init__.py
+++ b/src/mygrad/_utils/__init__.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from mygrad.operation_base import Operation
 
 __all__ = [
-    "is_invalid_gradient",
     "reduce_broadcast",
     "SkipGradient",
     "WeakRef",
@@ -145,22 +144,6 @@ def reduce_broadcast(grad, var_shape):
         grad = grad.sum(axis=keepdims, keepdims=True)
 
     return grad
-
-
-def is_invalid_gradient(grad: Any) -> bool:
-    """Returns ``True`` if ``grad`` is not array-like.
-
-    Parameters
-    ----------
-    grad : Any
-
-
-    Returns
-    -------
-    ``True`` if ``grad`` is invalid"""
-    return not isinstance(grad, (np.ndarray, Real)) or not np.issubdtype(
-        np.asarray(grad).dtype, np.number
-    )
 
 
 class ContextTracker(ABC):

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -26,13 +26,8 @@ import mygrad._utils.duplicating_graph as _dup
 import mygrad._utils.graph_tracking as _track
 import mygrad._utils.lock_management as _mem
 from mygrad._tensor_core_ops.indexing import GetItem, SetItem
-from mygrad._utils import (
-    WeakRef,
-    WeakRefIterable,
-    collect_all_operations,
-    is_invalid_gradient,
-)
-from mygrad.errors import DisconnectedView, InvalidGradient
+from mygrad._utils import WeakRef, WeakRefIterable, collect_all_operations
+from mygrad.errors import DisconnectedView
 from mygrad.linalg.ops import MatMul
 from mygrad.math.arithmetic.ops import (
     Add,
@@ -848,14 +843,6 @@ class Tensor:
             # `self` is guaranteed to be a tensor of floats
             # so we can simply cast `grad` to be the same dtype
             self._grad = asarray(grad, dtype=self.dtype)
-            if is_invalid_gradient(self._grad):
-                raise InvalidGradient(
-                    f"An invalid gradient-value was passed to "
-                    f"\n\t`{type(self).__name__}.backward(<gradient>)`"
-                    f"\nGradients are expected to be real-valued scalars or "
-                    f"numpy arrays, got a gradient of type: {type(grad)}"
-                    f"{grad}"
-                )
 
             if self._grad.shape != self.shape:
                 try:

--- a/tests/custom_strategies/__init__.py
+++ b/tests/custom_strategies/__init__.py
@@ -86,8 +86,7 @@ class VerboseTensor(Tensor):
         if self.grad is not None:
             replacement += f", grad={repr(self.grad)}"
         replacement += ")"
-        repr_ = repr_.replace(")", replacement)
-        return repr_
+        return repr_[:-1] + replacement
 
 
 @st.composite

--- a/tests/tensor_base/test_backward.py
+++ b/tests/tensor_base/test_backward.py
@@ -1,0 +1,83 @@
+import hypothesis.extra.numpy as hnp
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+from hypothesis import given
+from numpy.testing import assert_allclose
+
+import mygrad as mg
+from tests.custom_strategies import tensors
+
+
+def test_simple_behavior():
+    tensor = mg.Tensor([1.0, 2.0])
+
+    # default behavior
+    tensor.backward()
+    assert_allclose(tensor.grad, [1.0, 1.0])
+
+    # compatible with tensor, casts dtype, broadcasts
+    tensor.backward(mg.Tensor(2))
+    assert_allclose(tensor.grad, [2.0, 2.0])
+
+    # works with array-like, broadcasts
+    tensor.backward([3.0])
+    assert_allclose(tensor.grad, [3.0, 3.0])
+
+    with pytest.raises(ValueError):
+        # incompatible shape
+        tensor.backward(np.arange(3))
+
+
+@given(
+    tensor=tensors(
+        dtype=hnp.floating_dtypes(endianness="="),
+        fill=st.just(0),
+        constant=False,
+        shape=hnp.array_shapes(min_dims=0, min_side=0, max_dims=3),
+    ),
+    data=st.data(),
+)
+def test_tensor_backward_produces_grad_of_correct_dtype_and_shape(
+    tensor: mg.Tensor, data: st.DataObject
+):
+    arrays_broadcastable_into_tensor = hnp.arrays(
+        dtype=hnp.floating_dtypes(endianness="=") | hnp.integer_dtypes(endianness="="),
+        shape=hnp.broadcastable_shapes(
+            tensor.shape,
+            min_side=min(tensor.shape, default=0),
+            max_side=min(tensor.shape, default=0),
+            max_dims=tensor.ndim,
+        ),
+    )
+
+    grad = data.draw(st.none() | arrays_broadcastable_into_tensor, label="grad",)
+
+    tensor.backward(grad)
+    assert tensor.dtype == tensor.grad.dtype
+
+
+@given(
+    grad=hnp.array_shapes(min_dims=0, min_side=0, max_dims=4).map(
+        lambda shape: np.full(shape, 1.0)
+    ),
+    tensor=hnp.array_shapes(min_dims=0, min_side=0, max_dims=4).map(
+        lambda shape: mg.full(shape, 1.0)
+    ),
+)
+def test_incompatible_grad_shape_raises(grad: np.ndarray, tensor: mg.Tensor):
+    raises = False
+    try:
+        out = np.broadcast(tensor, grad)
+        if out.shape != tensor.shape:
+            raises = True
+    except ValueError:
+        raises = True
+
+    if not raises:
+        tensor.backward(grad)
+        assert tensor.shape == tensor.grad.shape
+        assert tensor.dtype == tensor.grad.dtype
+    else:
+        with pytest.raises(ValueError):
+            tensor.backward(grad)

--- a/tests/tensor_base/test_tensor.py
+++ b/tests/tensor_base/test_tensor.py
@@ -10,7 +10,7 @@ from pytest import raises
 
 import mygrad as mg
 from mygrad import Tensor
-from mygrad.errors import InvalidBackprop, InvalidGradient
+from mygrad.errors import InvalidBackprop
 from mygrad.linalg.ops import MatMul
 from mygrad.math.arithmetic.ops import Add, Divide, Multiply, Negative, Power, Subtract
 from mygrad.operation_base import Operation
@@ -165,11 +165,12 @@ def test_repr(tensor, repr_):
     assert repr(tensor) == repr_
 
 
+@pytest.mark.parametrize("bad_grads", ["bad", 1.0j])
 @given(constant=st.booleans())
-def test_invalid_gradient_raises(constant: bool):
+def test_invalid_gradient_raises(constant: bool, bad_grads):
     x = Tensor(3.0, constant=constant) * 2
-    with (pytest.raises(InvalidGradient) if not constant else does_not_raise()):
-        x.backward("bad")
+    with (pytest.raises((TypeError, ValueError)) if not constant else does_not_raise()):
+        x.backward(bad_grads)
 
 
 @pytest.mark.parametrize("element", (0, [0, 1, 2]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,17 +1,14 @@
-import weakref
-from numbers import Real
-from typing import List, Tuple
+from typing import Tuple
 
 import hypothesis.extra.numpy as hnp
 import hypothesis.strategies as st
 import numpy as np
-import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import given
 from numpy.testing import assert_allclose
 from pytest import raises
 
-from mygrad._utils import WeakRefIterable, is_invalid_gradient, reduce_broadcast
-from tests.custom_strategies import broadcastable_shapes, everything_except
+from mygrad._utils import WeakRefIterable, reduce_broadcast
+from tests.custom_strategies import broadcastable_shapes
 
 
 def test_weakrefs_list():
@@ -44,32 +41,6 @@ def test_weakrefs_bool():
     assert bool(weak_list) is True
     del a
     assert bool(weak_list) is False
-
-
-@pytest.mark.parametrize(
-    ("grad", "is_invalid"),
-    [
-        (everything_except((np.ndarray, Real)), True),
-        (None, True),
-        (np.ndarray([1], dtype="O"), True),
-        (
-            hnp.arrays(
-                shape=hnp.array_shapes(),
-                dtype=hnp.floating_dtypes(),
-                elements=st.floats(width=16),
-            ),
-            False,
-        ),
-        ((st.integers(min_value=int(-1e6), max_value=int(1e6)) | st.floats()), False),
-    ],
-)
-@settings(deadline=None, suppress_health_check=(HealthCheck.too_slow,))
-@given(data=st.data())
-def test_is_invalid_gradient(grad, is_invalid, data: st.DataObject):
-    if isinstance(grad, st.SearchStrategy):
-        grad = data.draw(grad, label="grad")
-
-    assert is_invalid_gradient(grad) is is_invalid, grad
 
 
 @given(shapes=hnp.mutually_broadcastable_shapes(num_shapes=2, max_dims=5))
@@ -171,8 +142,8 @@ def test_reduce_broadcast_keepdim(var_shape, data):
     grad=hnp.arrays(dtype=float, shape=(5, 3, 4, 2), elements=st.floats(-0.01, 0.01))
 )
 def test_hybrid_broadcasting(grad):
-    """ tests new-dim and keep-dim broadcasting
-         (3, 1, 2) -> (5, 3, 4, 2)"""
+    """tests new-dim and keep-dim broadcasting
+    (3, 1, 2) -> (5, 3, 4, 2)"""
     var_shape = (3, 1, 2)
     reduced = reduce_broadcast(grad=grad, var_shape=var_shape)
     answer = grad.sum(axis=0).sum(axis=-2, keepdims=True)


### PR DESCRIPTION
`tensor.backward(grad)` now supports `grad`  that can be broadcast into `tensor`. The resulting `tensor.grad`  will be cast to the correction (floating) dtype.