### PR TITLE
Tensor.__array__ should not accept a dtype parameter

### DIFF
--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1905,8 +1905,8 @@ class Tensor:
             "Use 'a = a @ b' instead of 'a @= b'"
         )
 
-    def __array__(self, dtype=None) -> np.ndarray:
-        return np.asarray(self.data, dtype)
+    def __array__(self) -> np.ndarray:
+        return np.asarray(self.data)
 
 
 # set all comparison operators - mirrors ndarray methods


### PR DESCRIPTION
It wasn't breaking anything but did not conform to the standard interface.