### PR TITLE
Operation refactoring

### DIFF
--- a/src/mygrad/_tensor_core_ops/indexing.py
+++ b/src/mygrad/_tensor_core_ops/indexing.py
@@ -4,7 +4,7 @@ from typing import Optional
 import numpy as np
 
 import mygrad._utils.graph_tracking as _tracking
-from mygrad.operation_base import BroadcastableOp, Operation
+from mygrad.operation_base import Operation
 
 __all__ = ["GetItem", "SetItem"]
 
@@ -105,7 +105,7 @@ def _arr(*shape: int) -> np.ndarray:
     return np.arange(np.prod(shape)).reshape(shape)
 
 
-class SetItem(BroadcastableOp):
+class SetItem(Operation):
     """Defines the __setitem__ interface for a Tensor, supporting back-propagation through
     both the tensor being set and the tensor whose .
 

--- a/src/mygrad/_tensor_core_ops/indexing.py
+++ b/src/mygrad/_tensor_core_ops/indexing.py
@@ -114,7 +114,7 @@ class SetItem(BroadcastableOp):
 
     can_return_view = True
 
-    def __call__(self, a, b, index, out: Optional[np.ndarray] = None):
+    def __call__(self, a, b, index, *, out: Optional[np.ndarray] = None):
         """a[index] = b
 
         Parameters
@@ -144,7 +144,6 @@ class SetItem(BroadcastableOp):
         if out is None:
             out = a.data
 
-        assert a.data is out
         self.variables = (a, b)
         self.index = index if isinstance(index, tuple) else (index,)
         out[index] = b.data

--- a/src/mygrad/_tensor_core_ops/indexing.py
+++ b/src/mygrad/_tensor_core_ops/indexing.py
@@ -1,4 +1,5 @@
 from numbers import Number
+from typing import Optional
 
 import numpy as np
 
@@ -113,7 +114,7 @@ class SetItem(BroadcastableOp):
 
     can_return_view = True
 
-    def __call__(self, a, b, index):
+    def __call__(self, a, b, index, out: Optional[np.ndarray] = None):
         """a[index] = b
 
         Parameters
@@ -130,13 +131,20 @@ class SetItem(BroadcastableOp):
             All means of numpy-array indexing (basic, advanced, mixed, etc) are
             supported.
 
+        out : Optional[ndarray]
+            The data to be mutated; defaults to ``a.data``. This argument is
+            included to provide parity with standard ufunc signatures.
+
         Notes
         -----
         Additional computational overhead is required for back-propagation when
         `index` contains any integer-valued arrays, to accommodate for the scenario
         in which a single element is set multiple times."""
 
-        out = a.data
+        if out is None:
+            out = a.data
+
+        assert a.data is out
         self.variables = (a, b)
         self.index = index if isinstance(index, tuple) else (index,)
         out[index] = b.data

--- a/src/mygrad/_tensor_core_ops/indexing.py
+++ b/src/mygrad/_tensor_core_ops/indexing.py
@@ -114,7 +114,7 @@ class SetItem(Operation):
 
     can_return_view = True
 
-    def __call__(self, a, b, index, *, out: Optional[np.ndarray] = None):
+    def __call__(self, a, b, index, *, out: np.ndarray):
         """a[index] = b
 
         Parameters
@@ -131,7 +131,7 @@ class SetItem(Operation):
             All means of numpy-array indexing (basic, advanced, mixed, etc) are
             supported.
 
-        out : Optional[ndarray]
+        out : ndarray
             The data to be mutated; defaults to ``a.data``. This argument is
             included to provide parity with standard ufunc signatures.
 
@@ -140,9 +140,6 @@ class SetItem(Operation):
         Additional computational overhead is required for back-propagation when
         `index` contains any integer-valued arrays, to accommodate for the scenario
         in which a single element is set multiple times."""
-
-        if out is None:
-            out = a.data
 
         self.variables = (a, b)
         self.index = index if isinstance(index, tuple) else (index,)

--- a/src/mygrad/_utils/duplicating_graph.py
+++ b/src/mygrad/_utils/duplicating_graph.py
@@ -14,7 +14,7 @@ from typing import (
 from numpy import ndarray
 
 from mygrad._utils import WeakRefIterable
-from mygrad.operation_base import BroadcastableOp, Operation
+from mygrad.operation_base import Operation
 
 if TYPE_CHECKING:  # pragma: no cover
     from mygrad import Tensor
@@ -213,7 +213,7 @@ class DuplicatingGraph:
                 node.tensor._base = self.base.tensor
 
 
-class UnView(BroadcastableOp):
+class UnView(Operation):
     """
     Creates an operation that connects a mutant base to
     the placeholder mutant-view and placeholder base that

--- a/src/mygrad/indexing_routines/ops.py
+++ b/src/mygrad/indexing_routines/ops.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from mygrad.operation_base import BroadcastableOp
+from mygrad.operation_base import Operation
 
 
-class Where(BroadcastableOp):
+class Where(Operation):
     def __call__(self, a, b, *, condition):
         self.variables = (a, b)
         self.condition = np.asarray(condition, dtype=bool)

--- a/src/mygrad/math/arithmetic/ops.py
+++ b/src/mygrad/math/arithmetic/ops.py
@@ -30,6 +30,8 @@ __all__ = [
     "MultiplySequence",
 ]
 
+# Binary Ops
+
 
 class Add(BinaryArith):
     numpy_ufunc = np.add
@@ -98,14 +100,6 @@ class _IDivide(Divide):
         return super().__call__(x1, x2, out=x1.data, where=where, dtype=dtype)
 
 
-class Reciprocal(UnaryArith):
-    numpy_ufunc = np.reciprocal
-
-    def backward_var(self, grad, index, **kwargs):
-        (a,) = self.variables
-        return -grad * np.reciprocal(a.data ** 2)
-
-
 class Power(BinaryArith):
     numpy_ufunc = np.power
 
@@ -123,6 +117,17 @@ class _IPower(Power):
         self, x1: "Tensor", x2: "Tensor", out=None, *, where=True, dtype=None
     ) -> np.ndarray:
         return super().__call__(x1, x2, out=x1.data, where=where, dtype=dtype)
+
+
+# Unary Ops
+
+
+class Reciprocal(UnaryArith):
+    numpy_ufunc = np.reciprocal
+
+    def backward_var(self, grad, index, **kwargs):
+        (a,) = self.variables
+        return -grad * np.reciprocal(a.data ** 2)
 
 
 class Square(UnaryArith):

--- a/src/mygrad/math/arithmetic/ops.py
+++ b/src/mygrad/math/arithmetic/ops.py
@@ -7,23 +7,16 @@ import numpy as np
 if TYPE_CHECKING:  # pragma: no cover
     from mygrad import Tensor
 
-from mygrad.operation_base import BinaryArith, BroadcastableOp, Operation, UnaryArith
+from mygrad.operation_base import BinaryArith, BroadcastableOp, UnaryArith
 
 __all__ = [
     "Add",
-    "_IAdd",
     "Subtract",
-    "_ISubtract",
     "Multiply",
-    "_IMultiply",
     "Divide",
-    "_IDivide",
     "Reciprocal",
     "Power",
-    "_IPower",
-    "_IPow1",
     "Square",
-    "_ISquare",
     "Positive",
     "Negative",
     "AddSequence",
@@ -40,13 +33,6 @@ class Add(BinaryArith):
         return grad
 
 
-class _IAdd(Add):
-    def __call__(
-        self, x1: "Tensor", x2: "Tensor", out=None, *, where=True, dtype=None
-    ) -> np.ndarray:
-        return super().__call__(x1, x2, out=x1.data, dtype=dtype, where=where)
-
-
 class Subtract(BinaryArith):
     numpy_ufunc = np.subtract
 
@@ -55,13 +41,6 @@ class Subtract(BinaryArith):
             return grad
         else:
             return -grad
-
-
-class _ISubtract(Subtract):
-    def __call__(
-        self, x1: "Tensor", x2: "Tensor", out=None, *, where=True, dtype=None
-    ) -> np.ndarray:
-        return super().__call__(x1, x2, out=x1.data, dtype=dtype, where=where)
 
 
 class Multiply(BinaryArith):
@@ -75,13 +54,6 @@ class Multiply(BinaryArith):
             return grad * a.data
 
 
-class _IMultiply(Multiply):
-    def __call__(
-        self, x1: "Tensor", x2: "Tensor", out=None, *, where=True, dtype=None
-    ) -> np.ndarray:
-        return super().__call__(x1, x2, out=x1.data, where=where, dtype=dtype)
-
-
 class Divide(BinaryArith):
     numpy_ufunc = np.divide
 
@@ -91,13 +63,6 @@ class Divide(BinaryArith):
             return grad / b.data
         else:  # broadcast through b
             return -grad * a.data / (b.data ** 2)
-
-
-class _IDivide(Divide):
-    def __call__(
-        self, x1: "Tensor", x2: "Tensor", out=None, *, where=True, dtype=None
-    ) -> np.ndarray:
-        return super().__call__(x1, x2, out=x1.data, where=where, dtype=dtype)
 
 
 class Power(BinaryArith):
@@ -110,13 +75,6 @@ class Power(BinaryArith):
             return grad * y * (x ** np.where(y, (y - 1), 1))
         else:
             return grad * (x ** y) * np.log(np.where(x, x, 1))
-
-
-class _IPower(Power):
-    def __call__(
-        self, x1: "Tensor", x2: "Tensor", out=None, *, where=True, dtype=None
-    ) -> np.ndarray:
-        return super().__call__(x1, x2, out=x1.data, where=where, dtype=dtype)
 
 
 # Unary Ops
@@ -136,31 +94,6 @@ class Square(UnaryArith):
     def backward_var(self, grad, index, **kwargs):
         grad = 2 * grad
         grad *= self.variables[index].data
-        return grad
-
-
-class _ISquare(Square):
-    def __call__(self, x1: "Tensor", out=None, *, where=True, dtype=None) -> np.ndarray:
-        return super().__call__(x1, out=x1.data, where=where, dtype=dtype)
-
-
-class _IPow1(Operation):
-    def __call__(self, inplace_target) -> np.ndarray:
-        """Performs a **= 1  (special case)
-
-        Parameters
-        ----------
-        inplace_target : mygrad.Tensor
-
-        Returns
-        -------
-        inplace_target_data : numpy.ndarray
-        """
-
-        self.variables = (inplace_target,)
-        return inplace_target.data
-
-    def backward_var(self, grad: np.ndarray, index: int, **kwargs) -> np.ndarray:
         return grad
 
 

--- a/src/mygrad/math/arithmetic/ops.py
+++ b/src/mygrad/math/arithmetic/ops.py
@@ -7,7 +7,7 @@ import numpy as np
 if TYPE_CHECKING:  # pragma: no cover
     from mygrad import Tensor
 
-from mygrad.operation_base import BinaryUfunc, BroadcastableOp, UnaryUfunc
+from mygrad.operation_base import BinaryUfunc, Operation, UnaryUfunc
 
 __all__ = [
     "Add",
@@ -111,7 +111,7 @@ class Negative(UnaryUfunc):
         return np.negative(grad, where=self.where)
 
 
-class AddSequence(BroadcastableOp):
+class AddSequence(Operation):
     """Performs f(a, b, ..., z) = a + b + ... + z"""
 
     def __call__(self, *input_vars):
@@ -124,7 +124,7 @@ class AddSequence(BroadcastableOp):
         return grad
 
 
-class MultiplySequence(BroadcastableOp):
+class MultiplySequence(Operation):
     """ Performs f(a, b, ..., z) = a * b * ... * z"""
 
     def __call__(self, *input_vars):

--- a/src/mygrad/math/arithmetic/ops.py
+++ b/src/mygrad/math/arithmetic/ops.py
@@ -7,7 +7,7 @@ import numpy as np
 if TYPE_CHECKING:  # pragma: no cover
     from mygrad import Tensor
 
-from mygrad.operation_base import BinaryArith, BroadcastableOp, UnaryArith
+from mygrad.operation_base import BinaryUfunc, BroadcastableOp, UnaryUfunc
 
 __all__ = [
     "Add",
@@ -26,14 +26,14 @@ __all__ = [
 # Binary Ops
 
 
-class Add(BinaryArith):
+class Add(BinaryUfunc):
     numpy_ufunc = np.add
 
     def backward_var(self, grad, index, **kwargs):
         return grad
 
 
-class Subtract(BinaryArith):
+class Subtract(BinaryUfunc):
     numpy_ufunc = np.subtract
 
     def backward_var(self, grad, index, **kwargs):
@@ -43,7 +43,7 @@ class Subtract(BinaryArith):
             return -grad
 
 
-class Multiply(BinaryArith):
+class Multiply(BinaryUfunc):
     numpy_ufunc = np.multiply
 
     def backward_var(self, grad, index, **kwargs):
@@ -54,7 +54,7 @@ class Multiply(BinaryArith):
             return grad * a.data
 
 
-class Divide(BinaryArith):
+class Divide(BinaryUfunc):
     numpy_ufunc = np.divide
 
     def backward_var(self, grad, index, **kwargs):
@@ -65,7 +65,7 @@ class Divide(BinaryArith):
             return -grad * a.data / (b.data ** 2)
 
 
-class Power(BinaryArith):
+class Power(BinaryUfunc):
     numpy_ufunc = np.power
 
     def backward_var(self, grad, index, **kwargs):
@@ -80,7 +80,7 @@ class Power(BinaryArith):
 # Unary Ops
 
 
-class Reciprocal(UnaryArith):
+class Reciprocal(UnaryUfunc):
     numpy_ufunc = np.reciprocal
 
     def backward_var(self, grad, index, **kwargs):
@@ -88,7 +88,7 @@ class Reciprocal(UnaryArith):
         return -grad * np.reciprocal(a.data ** 2)
 
 
-class Square(UnaryArith):
+class Square(UnaryUfunc):
     numpy_ufunc = np.square
 
     def backward_var(self, grad, index, **kwargs):
@@ -97,14 +97,14 @@ class Square(UnaryArith):
         return grad
 
 
-class Positive(UnaryArith):
+class Positive(UnaryUfunc):
     numpy_ufunc = np.positive
 
     def backward_var(self, grad, index, **kwargs):
         return np.positive(grad, where=self.where)
 
 
-class Negative(UnaryArith):
+class Negative(UnaryUfunc):
     numpy_ufunc = np.negative
 
     def backward_var(self, grad, index, **kwargs):

--- a/src/mygrad/math/exp_log/ops.py
+++ b/src/mygrad/math/exp_log/ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mygrad.operation_base import BinaryArith, UnaryArith
+from mygrad.operation_base import BinaryUfunc, UnaryUfunc
 
 __all__ = [
     "Exp",
@@ -15,28 +15,28 @@ __all__ = [
 ]
 
 
-class Exp(UnaryArith):
+class Exp(UnaryUfunc):
     numpy_ufunc = np.exp
 
     def backward_var(self, grad, index, **kwargs):
         return grad * np.exp(self.variables[index].data)
 
 
-class Exp2(UnaryArith):
+class Exp2(UnaryUfunc):
     numpy_ufunc = np.exp2
 
     def backward_var(self, grad, index, **kwargs):
         return grad * np.exp2(self.variables[index].data) * np.log(2)
 
 
-class Expm1(UnaryArith):
+class Expm1(UnaryUfunc):
     numpy_ufunc = np.expm1
 
     def backward_var(self, grad, index, **kwargs):
         return grad * np.exp(self.variables[index].data)
 
 
-class Logaddexp(BinaryArith):
+class Logaddexp(BinaryUfunc):
     numpy_ufunc = np.logaddexp
 
     def backward_var(self, grad, index, **kwargs):
@@ -49,7 +49,7 @@ class Logaddexp(BinaryArith):
             raise IndexError(f"Back-propagation through tensor-{index}")
 
 
-class Logaddexp2(BinaryArith):
+class Logaddexp2(BinaryUfunc):
     numpy_ufunc = np.logaddexp2
 
     def backward_var(self, grad, index, **kwargs):
@@ -62,28 +62,28 @@ class Logaddexp2(BinaryArith):
             raise IndexError(f"Back-propagation through tensor-{index}")
 
 
-class Log(UnaryArith):
+class Log(UnaryUfunc):
     numpy_ufunc = np.log
 
     def backward_var(self, grad, index, **kwargs):
         return grad / self.variables[index].data
 
 
-class Log2(UnaryArith):
+class Log2(UnaryUfunc):
     numpy_ufunc = np.log2
 
     def backward_var(self, grad, index, **kwargs):
         return grad / (self.variables[index].data * np.log(2))
 
 
-class Log10(UnaryArith):
+class Log10(UnaryUfunc):
     numpy_ufunc = np.log10
 
     def backward_var(self, grad, index, **kwargs):
         return grad / (self.variables[index].data * np.log(10))
 
 
-class Log1p(UnaryArith):
+class Log1p(UnaryUfunc):
     numpy_ufunc = np.log1p
 
     def backward_var(self, grad, index, **kwargs):

--- a/src/mygrad/math/exp_log/ops.py
+++ b/src/mygrad/math/exp_log/ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mygrad.operation_base import BroadcastableOp, Operation
+from mygrad.operation_base import BinaryArith, UnaryArith
 
 __all__ = [
     "Exp",
@@ -15,63 +15,29 @@ __all__ = [
 ]
 
 
-class Exp(Operation):
-    def __call__(self, a):
-        """f(a) -> exp(a)
-
-        Parameters
-        ----------
-        a : mygrad.Tensor
-
-        Returns
-        -------
-        numpy.ndarray"""
-        self.variables = (a,)
-        return np.exp(a.data)
+class Exp(UnaryArith):
+    numpy_ufunc = np.exp
 
     def backward_var(self, grad, index, **kwargs):
         return grad * np.exp(self.variables[index].data)
 
 
-class Exp2(Operation):
-    def __call__(self, a):
-        """f(a) -> 2^a
-
-        Parameters
-        ----------
-        a : mygrad.Tensor
-
-        Returns
-        -------
-        numpy.ndarray"""
-        self.variables = (a,)
-        return np.exp2(a.data)
+class Exp2(UnaryArith):
+    numpy_ufunc = np.exp2
 
     def backward_var(self, grad, index, **kwargs):
         return grad * np.exp2(self.variables[index].data) * np.log(2)
 
 
-class Expm1(Operation):
-    """f(a) -> exp(a) - 1
-
-    This function provides greater precision than exp(x) - 1
-    for small values of x."""
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.expm1(a.data)
+class Expm1(UnaryArith):
+    numpy_ufunc = np.expm1
 
     def backward_var(self, grad, index, **kwargs):
         return grad * np.exp(self.variables[index].data)
 
 
-class Logaddexp(BroadcastableOp):
-    """f(a,b) -> log(exp(a) + exp(b))"""
-
-    def __call__(self, a, b):
-        self.variables = (a, b)
-        out = np.logaddexp(a.data, b.data)
-        return out
+class Logaddexp(BinaryArith):
+    numpy_ufunc = np.logaddexp
 
     def backward_var(self, grad, index, **kwargs):
         a, b = self.variables
@@ -83,13 +49,8 @@ class Logaddexp(BroadcastableOp):
             raise IndexError(f"Back-propagation through tensor-{index}")
 
 
-class Logaddexp2(BroadcastableOp):
-    """f(a,b) -> log2(exp(a) + exp(b))"""
-
-    def __call__(self, a, b):
-        self.variables = (a, b)
-        out = np.logaddexp2(a.data, b.data)
-        return out
+class Logaddexp2(BinaryArith):
+    numpy_ufunc = np.logaddexp2
 
     def backward_var(self, grad, index, **kwargs):
         a, b = self.variables
@@ -101,47 +62,29 @@ class Logaddexp2(BroadcastableOp):
             raise IndexError(f"Back-propagation through tensor-{index}")
 
 
-class Log(Operation):
-    """ f(a) -> ln(a)"""
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.log(a.data)
+class Log(UnaryArith):
+    numpy_ufunc = np.log
 
     def backward_var(self, grad, index, **kwargs):
         return grad / self.variables[index].data
 
 
-class Log2(Operation):
-    def __call__(self, a):
-        """ f(a) -> log2(a)"""
-        self.variables = (a,)
-        return np.log2(a.data)
+class Log2(UnaryArith):
+    numpy_ufunc = np.log2
 
     def backward_var(self, grad, index, **kwargs):
         return grad / (self.variables[index].data * np.log(2))
 
 
-class Log10(Operation):
-    """ f(a) -> log10(a)"""
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.log10(a.data)
+class Log10(UnaryArith):
+    numpy_ufunc = np.log10
 
     def backward_var(self, grad, index, **kwargs):
         return grad / (self.variables[index].data * np.log(10))
 
 
-class Log1p(Operation):
-    """f(a) -> ln(1 + a)
-
-    log1p is accurate for x so small that 1 + x == 1 in
-    floating-point accuracy."""
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.log1p(a.data)
+class Log1p(UnaryArith):
+    numpy_ufunc = np.log1p
 
     def backward_var(self, grad, index, **kwargs):
         return grad / (1 + self.variables[index].data)

--- a/src/mygrad/math/hyperbolic_trig/ops.py
+++ b/src/mygrad/math/hyperbolic_trig/ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mygrad.operation_base import Operation, UnaryArith
+from mygrad.operation_base import Operation, UnaryUfunc
 
 __all__ = [
     "Sinh",
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-class Sinh(UnaryArith):
+class Sinh(UnaryUfunc):
     numpy_ufunc = np.sinh
 
     def backward_var(self, grad, index, **kwargs):
@@ -25,7 +25,7 @@ class Sinh(UnaryArith):
         return grad * np.cosh(a.data)
 
 
-class Cosh(UnaryArith):
+class Cosh(UnaryUfunc):
     numpy_ufunc = np.cosh
 
     def backward_var(self, grad, index, **kwargs):
@@ -33,7 +33,7 @@ class Cosh(UnaryArith):
         return grad * np.sinh(a.data)
 
 
-class Tanh(UnaryArith):
+class Tanh(UnaryUfunc):
     numpy_ufunc = np.tanh
 
     def backward_var(self, grad, index, **kwargs):
@@ -77,7 +77,7 @@ class Coth(Operation):
         return grad * -1 / np.sinh(a.data) ** 2
 
 
-class Arcsinh(UnaryArith):
+class Arcsinh(UnaryUfunc):
     numpy_ufunc = np.arcsinh
 
     def backward_var(self, grad, index, **kwargs):
@@ -85,7 +85,7 @@ class Arcsinh(UnaryArith):
         return grad / np.sqrt(1 + a.data ** 2)
 
 
-class Arccosh(UnaryArith):
+class Arccosh(UnaryUfunc):
     numpy_ufunc = np.arccosh
 
     def backward_var(self, grad, index, **kwargs):
@@ -93,7 +93,7 @@ class Arccosh(UnaryArith):
         return grad / np.sqrt(a.data ** 2 - 1)
 
 
-class Arctanh(UnaryArith):
+class Arctanh(UnaryUfunc):
     numpy_ufunc = np.arctanh
 
     def backward_var(self, grad, index, **kwargs):

--- a/src/mygrad/math/hyperbolic_trig/ops.py
+++ b/src/mygrad/math/hyperbolic_trig/ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mygrad.operation_base import Operation
+from mygrad.operation_base import Operation, UnaryArith
 
 __all__ = [
     "Sinh",
@@ -17,39 +17,27 @@ __all__ = [
 ]
 
 
-class Sinh(Operation):
-    """ f(a) -> sinh(a) """
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.sinh(a.data)
+class Sinh(UnaryArith):
+    numpy_ufunc = np.sinh
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * np.cosh(a.data)
 
 
-class Cosh(Operation):
-    """ f(a) -> cosh(a) """
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.cosh(a.data)
+class Cosh(UnaryArith):
+    numpy_ufunc = np.cosh
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * np.sinh(a.data)
 
 
-class Tanh(Operation):
-    """ f(a) -> tanh(a) """
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.tanh(a.data)
+class Tanh(UnaryArith):
+    numpy_ufunc = np.tanh
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * (1 - np.tanh(a.data) ** 2)
 
 
@@ -61,7 +49,7 @@ class Csch(Operation):
         return 1 / np.sinh(a.data)
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * -np.cosh(a.data) / np.sinh(a.data) ** 2
 
 
@@ -73,7 +61,7 @@ class Sech(Operation):
         return 1 / np.cosh(a.data)
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * -np.sinh(a.data) / np.cosh(a.data) ** 2
 
 
@@ -85,43 +73,31 @@ class Coth(Operation):
         return 1 / np.tanh(a.data)
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * -1 / np.sinh(a.data) ** 2
 
 
-class Arcsinh(Operation):
-    """ f(a) -> arcsinh(a) """
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.arcsinh(a.data)
+class Arcsinh(UnaryArith):
+    numpy_ufunc = np.arcsinh
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad / np.sqrt(1 + a.data ** 2)
 
 
-class Arccosh(Operation):
-    """ f(a) -> arccosh(a) """
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.arccosh(a.data)
+class Arccosh(UnaryArith):
+    numpy_ufunc = np.arccosh
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad / np.sqrt(a.data ** 2 - 1)
 
 
-class Arctanh(Operation):
-    """ f(a) -> arctanh(a) """
-
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.arctanh(a.data)
+class Arctanh(UnaryArith):
+    numpy_ufunc = np.arctanh
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad / (1 - a.data ** 2)
 
 
@@ -133,7 +109,7 @@ class Arccsch(Operation):
         return np.arcsinh(1 / a.data)
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return -grad / (np.abs(a.data) * np.sqrt(1 + a.data ** 2))
 
 
@@ -145,5 +121,5 @@ class Arccoth(Operation):
         return np.arctanh(1 / a.data)
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad / (1 - a.data ** 2)

--- a/src/mygrad/math/misc/ops.py
+++ b/src/mygrad/math/misc/ops.py
@@ -1,11 +1,11 @@
 import numpy as np
 
-from mygrad.operation_base import BinaryArith, UnaryArith
+from mygrad.operation_base import BinaryUfunc, UnaryUfunc
 
 __all__ = ["Abs", "Sqrt", "Cbrt", "Maximum", "Minimum"]
 
 
-class Abs(UnaryArith):
+class Abs(UnaryUfunc):
     numpy_ufunc = np.absolute
 
     def backward_var(self, grad, index, **kwargs):
@@ -15,7 +15,7 @@ class Abs(UnaryArith):
         )
 
 
-class Sqrt(UnaryArith):
+class Sqrt(UnaryUfunc):
     numpy_ufunc = np.sqrt
 
     def backward_var(self, grad, index, **kwargs):
@@ -23,7 +23,7 @@ class Sqrt(UnaryArith):
         return grad / (2 * np.sqrt(a.data))
 
 
-class Cbrt(UnaryArith):
+class Cbrt(UnaryUfunc):
     numpy_ufunc = np.cbrt
 
     def backward_var(self, grad, index, **kwargs):
@@ -31,7 +31,7 @@ class Cbrt(UnaryArith):
         return grad / (3 * np.cbrt(a.data ** 2))
 
 
-class Maximum(BinaryArith):
+class Maximum(BinaryUfunc):
     numpy_ufunc = np.maximum
 
     def __init__(self):
@@ -60,7 +60,7 @@ class Maximum(BinaryArith):
         return mask * grad
 
 
-class Minimum(BinaryArith):
+class Minimum(BinaryUfunc):
     numpy_ufunc = np.minimum
 
     def __init__(self):

--- a/src/mygrad/math/misc/ops.py
+++ b/src/mygrad/math/misc/ops.py
@@ -1,62 +1,58 @@
 import numpy as np
 
-from mygrad.operation_base import BroadcastableOp, Operation
+from mygrad.operation_base import BinaryArith, UnaryArith
 
 __all__ = ["Abs", "Sqrt", "Cbrt", "Maximum", "Minimum"]
 
 
-class Abs(Operation):
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.abs(a.data)
+class Abs(UnaryArith):
+    numpy_ufunc = np.absolute
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad * np.piecewise(
             a.data, [a.data < 0, a.data == 0, a.data > 0], [-1, np.nan, 1]
         )
 
 
-class Sqrt(Operation):
-    def __call__(self, a):
-        """f(a) = sqrt(a)
-
-        Parameters
-        ----------
-        a : mygrad.Tensor"""
-        self.variables = (a,)
-        return np.sqrt(a.data)
+class Sqrt(UnaryArith):
+    numpy_ufunc = np.sqrt
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad / (2 * np.sqrt(a.data))
 
 
-class Cbrt(Operation):
-    def __call__(self, a):
-        self.variables = (a,)
-        return np.cbrt(a.data)
+class Cbrt(UnaryArith):
+    numpy_ufunc = np.cbrt
 
     def backward_var(self, grad, index, **kwargs):
-        a = self.variables[index]
+        (a,) = self.variables
         return grad / (3 * np.cbrt(a.data ** 2))
 
 
-class Maximum(BroadcastableOp):
-    def __call__(self, a, b):
-        self.variables = (a, b)
-        self.greater_than_mask = a.data > b.data
-        self.equal_mask = a.data == b.data
-        return np.where(self.greater_than_mask, a.data, b.data)
+class Maximum(BinaryArith):
+    numpy_ufunc = np.maximum
+
+    def __init__(self):
+        super().__init__()
+        self.greater_than_mask = None
 
     def backward_var(self, grad, index, **kwargs):
+        a, b = self.variables
+
+        if self.greater_than_mask is None:
+            self.greater_than_mask = a.data > b.data
+
         if index == 0:
             mask = self.greater_than_mask
         elif index == 1:
+            equal_mask = a.data == b.data
             mask = np.logical_not(self.greater_than_mask)
+
             if mask.ndim:
-                np.logical_not(mask, out=mask, where=self.equal_mask)
-            elif self.equal_mask:
+                np.logical_not(mask, out=mask, where=equal_mask)
+            elif equal_mask:
                 mask = np.logical_not(mask)
         else:  # pragma: no cover
             raise IndexError(f"Back-propagation through tensor-{index}")
@@ -64,21 +60,29 @@ class Maximum(BroadcastableOp):
         return mask * grad
 
 
-class Minimum(BroadcastableOp):
-    def __call__(self, a, b):
-        self.variables = (a, b)
-        self.less_than_mask = a.data < b.data
-        self.equal_mask = a.data == b.data
-        return np.where(self.less_than_mask, a.data, b.data)
+class Minimum(BinaryArith):
+    numpy_ufunc = np.minimum
+
+    def __init__(self):
+        super().__init__()
+        self.less_than_mask = None
+        self.equal_mask = None
 
     def backward_var(self, grad, index, **kwargs):
+        a, b = self.variables
+
+        if self.less_than_mask is None:
+            self.less_than_mask = a.data < b.data
+
         if index == 0:
             mask = self.less_than_mask
         elif index == 1:
             mask = np.logical_not(self.less_than_mask)
+            equal_mask = a.data == b.data
+
             if mask.ndim:
-                np.logical_not(mask, out=mask, where=self.equal_mask)
-            elif self.equal_mask:
+                np.logical_not(mask, out=mask, where=equal_mask)
+            elif equal_mask:
                 mask = np.logical_not(mask)
         else:  # pragma: no cover
             raise IndexError(f"Back-propagation through tensor-{index}")

--- a/src/mygrad/math/misc/ops.py
+++ b/src/mygrad/math/misc/ops.py
@@ -37,7 +37,9 @@ class Cbrt(UnaryUfunc):
 class _MaxMin(BinaryUfunc, ABC):
     @staticmethod
     @abstractmethod
-    def _comparison(self, x1: np.ndarray, x2: np.ndarray) -> np.ndarray:
+    def _comparison(
+        self, x1: np.ndarray, x2: np.ndarray
+    ) -> np.ndarray:  # pragma: no cover
         """Returns `True` where elements of the output were derived from `x1`.
 
         I.e. max => x1 > x2  ;  min => x1 < x2"""

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -92,7 +92,9 @@ def sum(x, axis=None, keepdims=False, constant=False):
     >>> mg.sum([10], initial=5)
     Tensor(15)
     """
-    return Tensor._op(Sum, x, op_args=(axis, keepdims), constant=constant)
+    return Tensor._op(
+        Sum, x, op_kwargs=dict(axis=axis, keepdims=keepdims), constant=constant
+    )
 
 
 def mean(x, axis=None, keepdims=False, constant=False):
@@ -154,7 +156,9 @@ def mean(x, axis=None, keepdims=False, constant=False):
     >>> mg.mean(a, dtype=np.float64)
     Tensor(0.55000000074505806)
     """
-    return Tensor._op(Mean, x, op_args=(axis, keepdims), constant=constant)
+    return Tensor._op(
+        Mean, x, op_kwargs=dict(axis=axis, keepdims=keepdims), constant=constant
+    )
 
 
 def var(x, axis=None, ddof=0, keepdims=False, constant=False):

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -1,3 +1,4 @@
+from mygrad.operation_base import _NoValue
 from mygrad.tensor_base import Tensor
 
 from .ops import *
@@ -370,9 +371,9 @@ def max(x, axis=None, keepdims=False, constant=False):
     Tensor(nan)
     """
     return Tensor._op(
-        MaxMin,
+        Max,
         x,
-        op_kwargs=dict(axis=axis, keepdims=keepdims, maxmin="max"),
+        op_kwargs=dict(axis=axis, keepdims=keepdims, dtype=_NoValue),
         constant=constant,
     )
 
@@ -420,9 +421,9 @@ def min(x, axis=None, keepdims=False, constant=False):
     Tensor(nan)
     """
     return Tensor._op(
-        MaxMin,
+        Min,
         x,
-        op_kwargs=dict(axis=axis, keepdims=keepdims, maxmin="min"),
+        op_kwargs=dict(axis=axis, keepdims=keepdims, dtype=_NoValue),
         constant=constant,
     )
 

--- a/src/mygrad/math/sequential/ops.py
+++ b/src/mygrad/math/sequential/ops.py
@@ -32,7 +32,7 @@ class MaxMin(Sequential, ABC):
     ) -> np.ndarray:
         """`numpy.argmax` or `numpy.argmin` - in correspondence with the
         implementation of `max` or `min`."""
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     @staticmethod
     @abstractmethod
@@ -43,7 +43,7 @@ class MaxMin(Sequential, ABC):
         *args,
         **kwargs,
     ) -> np.ndarray:
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     def backward_var(self, grad, index, **kwargs):
         (a,) = self.variables
@@ -55,7 +55,7 @@ class MaxMin(Sequential, ABC):
         if hasattr(axis, "__iter__"):
             axis = tuple(ax % a.ndim for ax in axis)
             axis = None if len(axis) == a.ndim else tuple(sorted(axis))
-        elif axis is not None:
+        elif axis is not None:  # pragma: no cover
             axis = (axis % a.ndim,)
 
         # normalize shape of grad to be same as when keepdims=False

--- a/src/mygrad/math/sequential/ops.py
+++ b/src/mygrad/math/sequential/ops.py
@@ -21,6 +21,9 @@ __all__ = [
 
 
 class MaxMin(Sequential, ABC):
+    """A base class that implements common functionality for back-propping
+    through numpy.max and numpy.min"""
+
     @staticmethod
     @abstractmethod
     def _arg_finder(

--- a/src/mygrad/math/sequential/ops.py
+++ b/src/mygrad/math/sequential/ops.py
@@ -34,7 +34,6 @@ class MaxMin(Sequential, ABC):
     @staticmethod
     @abstractmethod
     def numpy_func(
-        self,
         a: np.ndarray,
         axis: Optional[Union[int, Tuple[int, ...]]] = None,
         out: Optional[np.ndarray] = None,

--- a/src/mygrad/math/trigonometric/ops.py
+++ b/src/mygrad/math/trigonometric/ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mygrad.operation_base import BinaryArith, Operation, UnaryArith
+from mygrad.operation_base import BinaryUfunc, Operation, UnaryUfunc
 
 __all__ = [
     "Sin",
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-class Sin(UnaryArith):
+class Sin(UnaryUfunc):
     numpy_ufunc = np.sin
 
     def backward_var(self, grad, index, **kwargs):
@@ -46,7 +46,7 @@ class Sinc(Operation):
         return np.pi * grad * np.piecewise(x, [x == 0, x != 0], [np.zeros_like, _dsinc])
 
 
-class Cos(UnaryArith):
+class Cos(UnaryUfunc):
     numpy_ufunc = np.cos
 
     def backward_var(self, grad, index, **kwargs):
@@ -54,7 +54,7 @@ class Cos(UnaryArith):
         return grad * -np.sin(a.data)
 
 
-class Tan(UnaryArith):
+class Tan(UnaryUfunc):
     numpy_ufunc = np.tan
 
     def backward_var(self, grad, index, **kwargs):
@@ -98,7 +98,7 @@ class Cot(Operation):
         return -grad / np.sin(a.data) ** 2
 
 
-class Arcsin(UnaryArith):
+class Arcsin(UnaryUfunc):
     numpy_ufunc = np.arcsin
 
     def backward_var(self, grad, index, **kwargs):
@@ -107,7 +107,7 @@ class Arcsin(UnaryArith):
         return np.select([np.abs(a.data) != 1], [grad / np.sqrt(1 - a.data ** 2)])
 
 
-class Arccos(UnaryArith):
+class Arccos(UnaryUfunc):
     numpy_ufunc = np.arccos
 
     def backward_var(self, grad, index, **kwargs):
@@ -116,7 +116,7 @@ class Arccos(UnaryArith):
         return np.select([np.abs(a.data) != 1], [-grad / np.sqrt(1 - a.data ** 2)])
 
 
-class Arctan(UnaryArith):
+class Arctan(UnaryUfunc):
     numpy_ufunc = np.arctan
 
     def backward_var(self, grad, index, **kwargs):
@@ -172,7 +172,7 @@ class Arccot(Operation):
         return -grad / (1 + a.data ** 2)
 
 
-class Arctan2(BinaryArith):
+class Arctan2(BinaryUfunc):
     numpy_ufunc = np.arctan2
 
     def __init__(self):

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 __all__ = [
     "Operation",
-    "BroadcastableOp",
     "Ufunc",
     "UnaryUfunc",
     "BinaryUfunc",
@@ -227,10 +226,6 @@ class Operation(ABC):
             visited.add(var_id)
             var._accum_ops.add(ref_op)
             var._backward(graph=graph)
-
-
-class BroadcastableOp(Operation, ABC):
-    """ Signals that an Operation's forward pass can broadcast its tensor arguments."""
 
 
 class Ufunc(Operation, ABC):

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -15,7 +15,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from mygrad import Tensor
     from mygrad._utils import WeakRef
 
-__all__ = ["Operation", "BroadcastableOp", "Ufunc"]
+__all__ = [
+    "Operation",
+    "BroadcastableOp",
+    "Ufunc",
+    "UnaryArith",
+    "BinaryArith",
+]
 
 
 class Operation(ABC):

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -300,43 +300,42 @@ class UnaryUfunc(Ufunc, ABC):
         where: Union[bool, np.ndarray] = True,
         dtype=None,
     ) -> np.ndarray:
-        """
-        f(x1, out=None, *, where=True, dtype=None)
+        """f(x1, out=None, *, where=True, dtype=None)
 
-                Parameters
-                ----------
-                x1 : Tensor, shape-(...)
-                    The input to the operation.
+        Parameters
+        ----------
+        x1 : Tensor, shape-(...)
+            The input to the operation.
 
-                    This tensor is saved to the state of the operation instance
-                    so that back-prop can be performed through it.
+            This tensor is saved to the state of the operation instance
+            so that back-prop can be performed through it.
 
-                out : Optional[np.ndarray]
-                    A location into which the result is stored. If provided, it must
-                    have a shape that the inputs broadcast to. If not provided or None,
-                    a freshly-allocated array is returned.
+        out : Optional[np.ndarray]
+            A location into which the result is stored. If provided, it must
+            have a shape that the inputs broadcast to. If not provided or None,
+            a freshly-allocated array is returned.
 
-                where: Union[bool, np.ndarray]
-                    Accepts a boolean array which is broadcast together with ``x1``.
-                    Values of True indicate to calculate the ufunc at that position, values
-                    of False indicate to leave the value in the output alone.
+        where: Union[bool, np.ndarray]
+            Accepts a boolean array which is broadcast together with ``x1``.
+            Values of True indicate to calculate the ufunc at that position, values
+            of False indicate to leave the value in the output alone.
 
-                dtype : Optional[numpy.dtype, str, object]
-                    Overrides the dtype of the calculation and output array.
+        dtype : Optional[numpy.dtype, str, object]
+            Overrides the dtype of the calculation and output array.
 
-                Returns
-                -------
-                y : ndarray, shape-(...)
-                    A numpy array of the same shape as ``x1`` with the ufunc applied
-                    elementwise on ``x1``.
+        Returns
+        -------
+        y : ndarray, shape-(...)
+            A numpy array of the same shape as ``x1`` with the ufunc applied
+            elementwise on ``x1``.
 
-                Notes
-                -----
-                This docstring was adapted from numpy's documentation [1]_.
+        Notes
+        -----
+        This docstring was adapted from numpy's documentation [1]_.
 
-                References
-                ----------
-                .. [1] Retrieved from https://numpy.org/doc/stable/reference/generated/numpy.sqrt.html
+        References
+        ----------
+        .. [1] Retrieved from https://numpy.org/doc/stable/reference/generated/numpy.sqrt.html
         """
         self.variables: Tuple["Tensor"] = (x1,)
         if where is not True:

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -171,6 +171,11 @@ class Operation(ABC):
         """
         for index, var in enumerate(self.variables):
             if not var.constant:
+                if self.where is not True:  # pragma: no cover
+                    raise NotImplementedError(
+                        "Backprop is not supported for operations that "
+                        "were filtered through a `where` boolean mask."
+                    )
                 if not var._ops:
                     raise InvalidBackprop(
                         f"Part of the computational graph containing "

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -358,7 +358,10 @@ class Sequential(Operation, ABC):
         if ddof is not _NoValue:
             kwargs["ddof"] = ddof
 
-        out = self.numpy_func(a.data, axis=axis, dtype=dtype, out=out, **kwargs)
+        if dtype is not _NoValue:
+            kwargs["dtype"] = dtype
+
+        out = self.numpy_func(a.data, axis=axis, out=out, **kwargs)
         self.out_shape = out.shape
 
         return out

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -155,8 +155,10 @@ class Operation(ABC):
         graph: Set["WeakRef[Operation]"],
         **kwargs,
     ):
-        """Back-propagates the gradient through all of the operation's inputs.
-        Constant tensors do not propagate a gradient.
+        """Back-propagates the gradient through all of the operation's inputs,
+        which are stored in the tuple `self.variables`.
+
+        Constant tensors (`tensor.constant is True`) skipped by this process.
 
         Parameters
         ----------
@@ -232,6 +234,18 @@ class BroadcastableOp(Operation, ABC):
 
 
 class Ufunc(Operation, ABC):
+    """The base class for mygrad's universal functions.
+
+    'A universal function (or ufunc for short) is a function that operates on
+    ndarrays in an element-by-element fashion, supporting array broadcasting, type casting,
+    and several other standard features. That is, a ufunc is a “vectorized” wrapper for a
+    function that takes a fixed number of specific inputs and produces a fixed number of
+    specific outputs.' [1]_
+
+    References
+    ----------
+    .. [1] Retrieved from https://numpy.org/doc/stable/reference/ufuncs.html"""
+
     @property
     @abstractmethod
     def numpy_ufunc(self) -> np.ufunc:
@@ -274,6 +288,10 @@ class Ufunc(Operation, ABC):
 
 
 class UnaryUfunc(Ufunc, ABC):
+    """A base class that specifies the common interface to – and facilitates
+    back-prop through – ufuncs that operate on a single array argument;
+    e.g. `mygrad.sin`, `mygrad.negative`."""
+
     def __call__(
         self,
         x1: "Tensor",
@@ -282,6 +300,44 @@ class UnaryUfunc(Ufunc, ABC):
         where: Union[bool, np.ndarray] = True,
         dtype=None,
     ) -> np.ndarray:
+        """
+        f(x1, out=None, *, where=True, dtype=None)
+
+                Parameters
+                ----------
+                x1 : Tensor, shape-(...)
+                    The input to the operation.
+
+                    This tensor is saved to the state of the operation instance
+                    so that back-prop can be performed through it.
+
+                out : Optional[np.ndarray]
+                    A location into which the result is stored. If provided, it must
+                    have a shape that the inputs broadcast to. If not provided or None,
+                    a freshly-allocated array is returned.
+
+                where: Union[bool, np.ndarray]
+                    Accepts a boolean array which is broadcast together with ``x1``.
+                    Values of True indicate to calculate the ufunc at that position, values
+                    of False indicate to leave the value in the output alone.
+
+                dtype : Optional[numpy.dtype, str, object]
+                    Overrides the dtype of the calculation and output array.
+
+                Returns
+                -------
+                y : ndarray, shape-(...)
+                    A numpy array of the same shape as ``x1`` with the ufunc applied
+                    elementwise on ``x1``.
+
+                Notes
+                -----
+                This docstring was adapted from numpy's documentation [1]_.
+
+                References
+                ----------
+                .. [1] Retrieved from https://numpy.org/doc/stable/reference/generated/numpy.sqrt.html
+        """
         self.variables: Tuple["Tensor"] = (x1,)
         if where is not True:
             self.where = where
@@ -289,6 +345,11 @@ class UnaryUfunc(Ufunc, ABC):
 
 
 class BinaryUfunc(Ufunc, ABC):
+    """A base class that specifies the common interface to – and facilitates
+    back-prop through – mygrad's ufuncs that operate on a two array arguments;
+    e.g. `mygrad.add`, `mygrad.multiply`.
+    """
+
     def __call__(
         self,
         x1: "Tensor",
@@ -298,6 +359,53 @@ class BinaryUfunc(Ufunc, ABC):
         where: Union[bool, np.ndarray, _NoValueType] = True,
         dtype=None,
     ) -> np.ndarray:
+        """f(x1, x2, out=None, *, where=True, dtype=None)
+
+        Parameters
+        ----------
+        x1 : Tensor
+            The first input to the operation.
+
+            This tensor is saved to the state of the operation instance
+            so that back-prop can be performed through it.
+
+        x2 : Tensor
+            The second input to the operation.
+
+            This tensor is saved to the state of the operation instance
+            so that back-prop can be performed through it.
+
+        out : Optional[np.ndarray]
+            A location into which the result is stored. If provided, it must
+            have a shape that the inputs broadcast to. If not provided or None,
+            a freshly-allocated array is returned.
+
+        where: Union[bool, np.ndarray]
+            Accepts a boolean array which is broadcast jointly with ``x1`` and ``x2``.
+            Values of True indicate to calculate the ufunc at that position, values
+            of False indicate to leave the value in the output alone.
+
+        dtype : Optional[numpy.dtype, str, object]
+            Overrides the dtype of the calculation and output array.
+
+        Returns
+        -------
+        y : ndarray
+            A numpy array resulting from the elementwise application of the ufunc to
+            corresponding pairs of elements from ``x1`` and ``x2``, respectively.
+
+            If ``x1`` and ``x2`` are of different shapes, then the operation is broadcast
+            across them [1]_.
+
+        Notes
+        -----
+        This docstring was adapted from numpy's documentation [2]_.
+
+        References
+        ----------
+        .. [1] https://numpy.org/doc/stable/user/basics.broadcasting.html
+        .. [2] Retrieved from https://numpy.org/doc/stable/reference/generated/numpy.add.html
+        """
         self.variables: Tuple["Tensor", "Tensor"] = (x1, x2)
         if where is not True and where is not _NoValue:
             self.where = where
@@ -307,6 +415,10 @@ class BinaryUfunc(Ufunc, ABC):
 
 
 class Sequential(Operation, ABC):
+    """A base class that specifies the common interface to – and facilitates
+    back-prop through – numpy's sequential functions; e.g. `numpy.sum`, `numpy.var`,
+    `numpy.max`"""
+
     numpy_func: Callable[..., np.ndarray]
     _integer_axis_only: bool = False
 

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -40,7 +40,7 @@ class _NoValueType:
             cls.__instance = super(_NoValueType, cls).__new__(cls)
         return cls.__instance
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<no value>"
 
 
@@ -244,7 +244,7 @@ class Ufunc(Operation, ABC):
     @property
     @abstractmethod
     def numpy_ufunc(self) -> np.ufunc:
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     @property
     def nin(self) -> int:
@@ -426,7 +426,7 @@ class Sequential(Operation, ABC):
         *args,
         **kwargs,
     ) -> np.ndarray:
-        raise NotImplementedError()
+        raise NotImplementedError()  # pragma: no cover
 
     def __init__(self):
         self.axis: Optional[Union[int, Tuple[int, ...]]]
@@ -472,7 +472,7 @@ class Sequential(Operation, ABC):
         if keepdims is not _NoValue:
             kwargs["keepdims"] = keepdims
 
-        if initial is not _NoValue:
+        if initial is not _NoValue:  # pragma: no cover
             kwargs["initial"] = initial
 
         if where is not _NoValue:

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -232,7 +232,10 @@ class BroadcastableOp(Operation, ABC):
 
 
 class Ufunc(Operation, ABC):
-    numpy_ufunc: np.ufunc
+    @property
+    @abstractmethod
+    def numpy_ufunc(self) -> np.ufunc:
+        raise NotImplementedError()
 
     @property
     def nin(self) -> int:
@@ -306,6 +309,19 @@ class BinaryUfunc(Ufunc, ABC):
 class Sequential(Operation, ABC):
     numpy_func: Callable[..., np.ndarray]
     _integer_axis_only: bool = False
+
+    @staticmethod
+    @abstractmethod
+    def numpy_func(
+        self,
+        a: np.ndarray,
+        axis: Optional[Union[int, Tuple[int, ...]]] = None,
+        dtype=None,
+        out: Optional[np.ndarray] = None,
+        *args,
+        **kwargs,
+    ) -> np.ndarray:
+        raise NotImplementedError()
 
     def __init__(self):
         self.axis: Optional[Union[int, Tuple[int, ...]]]

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -19,8 +19,8 @@ __all__ = [
     "Operation",
     "BroadcastableOp",
     "Ufunc",
-    "UnaryArith",
-    "BinaryArith",
+    "UnaryUfunc",
+    "BinaryUfunc",
     "Sequential",
 ]
 
@@ -270,7 +270,7 @@ class Ufunc(Operation, ABC):
         return self.numpy_ufunc.signature
 
 
-class UnaryArith(Ufunc, ABC):
+class UnaryUfunc(Ufunc, ABC):
     def __call__(
         self,
         x1: "Tensor",
@@ -285,20 +285,22 @@ class UnaryArith(Ufunc, ABC):
         return self.numpy_ufunc(x1.data, out=out, where=where, dtype=dtype)
 
 
-class BinaryArith(Ufunc, ABC):
+class BinaryUfunc(Ufunc, ABC):
     def __call__(
         self,
         x1: "Tensor",
         x2: "Tensor",
         out: Optional[np.ndarray] = None,
         *,
-        where: Union[bool, np.ndarray] = True,
+        where: Union[bool, np.ndarray, _NoValueType] = True,
         dtype=None,
     ) -> np.ndarray:
         self.variables: Tuple["Tensor", "Tensor"] = (x1, x2)
-        if where is not True:
+        if where is not True and where is not _NoValue:
             self.where = where
-        return self.numpy_ufunc(x1.data, x2.data, out=out, where=where, dtype=dtype)
+            return self.numpy_ufunc(x1.data, x2.data, out=out, where=where, dtype=dtype)
+        else:
+            return self.numpy_ufunc(x1.data, x2.data, out=out, dtype=dtype)
 
 
 class Sequential(Operation, ABC):

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -173,8 +173,8 @@ class Operation(ABC):
             if not var.constant:
                 if self.where is not True:  # pragma: no cover
                     raise NotImplementedError(
-                        "Backprop is not supported for operations that "
-                        "were filtered through a `where` boolean mask."
+                        f"{self} - Backprop is not supported for operations that "
+                        f"were filtered through a `where` ({self.where}) boolean mask."
                     )
                 if not var._ops:
                     raise InvalidBackprop(
@@ -454,7 +454,7 @@ class Sequential(Operation, ABC):
     ) -> np.ndarray:
         self.variables: Tuple["Tensor"] = (a,)
 
-        if where is not True:
+        if where is not True and where is not _NoValue:
             self.where = where
 
         self.keepdims = keepdims

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -313,7 +313,6 @@ class Sequential(Operation, ABC):
     @staticmethod
     @abstractmethod
     def numpy_func(
-        self,
         a: np.ndarray,
         axis: Optional[Union[int, Tuple[int, ...]]] = None,
         dtype=None,

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -858,7 +858,7 @@ class Tensor:
             finalize(f, _mem.release_writeability_lock_on_op, tensor_refs)
         return out
 
-    def _replay_op(self, *input_vars: "Tensor") -> "Tensor":
+    def _replay_op(self, *input_vars: Union[np.ndarray, "Tensor"]) -> "Tensor":
         """*dev use only*
 
         Replays the op that produced `self` - called on the specified

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1393,15 +1393,6 @@ class Tensor:
             graph.restore_old_graph()
             raise e
 
-        if placeholder_mutant_view.base is inplace_target:
-            # Because `out` and `in_place_target` hold the same ndarray,
-            # `out` was marked as a view of `in_place_target`. However,
-            # this is not a true "base/view-child" relationship but merely
-            # an edge case not accommodated by `Tensor._op` when determining
-            # base/view relationships. Thus `out` should not be considered a
-            # view under these circumstances.
-            placeholder_mutant_view._base = None
-
         # Connect public base tensor to placeholder graph via the mutated placeholder
         # tensor `out`.
         if self.base is None:

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -39,7 +39,7 @@ from mygrad.math.arithmetic.ops import (
     Square,
     Subtract,
 )
-from mygrad.operation_base import BroadcastableOp, Operation
+from mygrad.operation_base import Operation
 from mygrad.tensor_manip.array_shape.ops import Flatten, Reshape
 from mygrad.tensor_manip.transpose_like.ops import Tensor_Transpose_Property
 
@@ -1202,7 +1202,7 @@ class Tensor:
         return self._constant
 
     @property
-    def creator(self) -> Union[Operation, BroadcastableOp]:
+    def creator(self) -> Operation:
         """The ``Operation`` instance that produced ``self``.
 
         Returns

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -44,7 +44,7 @@ from mygrad.math.arithmetic.ops import (
     _IPow1,
     _IPower,
     _ISquare,
-    _ISubstract,
+    _ISubtract,
 )
 from mygrad.operation_base import BroadcastableOp, Operation
 from mygrad.tensor_manip.array_shape.ops import Flatten, Reshape
@@ -1631,7 +1631,7 @@ class Tensor:
         return self._op(Subtract, self, other)
 
     def __isub__(self, other) -> "Tensor":
-        self._in_place_op(_ISubstract, other)
+        self._in_place_op(_ISubtract, other)
         return self
 
     def __rsub__(self, other) -> "Tensor":

--- a/src/mygrad/tensor_manip/array_shape/ops.py
+++ b/src/mygrad/tensor_manip/array_shape/ops.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from mygrad.operation_base import BroadcastableOp, Operation
+from mygrad.operation_base import Operation
 
 __all__ = ["Reshape", "Flatten", "Squeeze", "Ravel", "ExpandDims", "BroadcastTo"]
 
@@ -87,7 +87,7 @@ class ExpandDims(Operation):
         return grad.reshape(a.shape)
 
 
-class BroadcastTo(BroadcastableOp):
+class BroadcastTo(Operation):
     can_return_view = True
 
     def __call__(self, a, shape):

--- a/src/mygrad/tensor_manip/tiling/ops.py
+++ b/src/mygrad/tensor_manip/tiling/ops.py
@@ -3,13 +3,13 @@ from typing import Optional, Sequence, Union
 import numpy as np
 
 from mygrad.nnet.layers.utils import sliding_window_view
-from mygrad.operation_base import BroadcastableOp
+from mygrad.operation_base import Operation
 from mygrad.tensor_base import Tensor
 
 __all__ = ["Repeat"]
 
 
-class Repeat(BroadcastableOp):
+class Repeat(Operation):
     # Repeat can broadcast in the case:
     #    repeat(1, 2) -> [1 1]
 

--- a/src/mygrad/test_ufuncs.py
+++ b/src/mygrad/test_ufuncs.py
@@ -1,0 +1,35 @@
+import inspect
+from typing import Type
+
+import pytest
+
+from mygrad.operation_base import Ufunc
+
+
+def all_subclasses(cls):
+    return set(cls.__subclasses__()).union(
+        (s for c in cls.__subclasses__() for s in all_subclasses(c))
+    )
+
+
+all_concrete_ufuncs = [
+    ufunc for ufunc in all_subclasses(Ufunc) if not inspect.isabstract(ufunc)
+]
+
+
+@pytest.mark.parametrize("ufunc", all_concrete_ufuncs)
+@pytest.mark.parametrize(
+    "attribute",
+    [
+        "nin",
+        "nout",
+        "nargs",
+        "ntypes",
+        "types",
+        "identity",
+        "signature",
+    ],
+)
+def test_ufunc_attributes_match_numpy_counterpart(ufunc: Type[Ufunc], attribute: str):
+    ufunc = ufunc()
+    assert getattr(ufunc, attribute) == getattr(ufunc.numpy_ufunc, attribute)

--- a/src/mygrad/test_ufuncs.py
+++ b/src/mygrad/test_ufuncs.py
@@ -1,6 +1,7 @@
 import inspect
 from typing import Type
 
+import numpy as np
 import pytest
 
 from mygrad.operation_base import Ufunc
@@ -33,3 +34,8 @@ all_concrete_ufuncs = [
 def test_ufunc_attributes_match_numpy_counterpart(ufunc: Type[Ufunc], attribute: str):
     ufunc = ufunc()
     assert getattr(ufunc, attribute) == getattr(ufunc.numpy_ufunc, attribute)
+
+
+@pytest.mark.parametrize("ufunc", all_concrete_ufuncs)
+def test_numpy_ufunc_is_actually_a_ufunc(ufunc: Type[Ufunc]):
+    assert isinstance(ufunc.numpy_ufunc, np.ufunc)

--- a/tests/test_in_place_semantics.py
+++ b/tests/test_in_place_semantics.py
@@ -569,3 +569,14 @@ def test_unview_backprop_through_multiple_view_funcs():
     out.backward()
 
     assert_array_equal(x.grad, coeff)
+
+
+def test_op_wrapper_supports_inplace_target():
+    from mygrad.math.arithmetic.ops import Multiply
+
+    x_orig = mg.arange(3.0)
+    x = +x_orig
+    Tensor._op(Multiply, x, x, out=x)
+    assert_allclose(x, mg.arange(3) ** 2)
+    x.backward()
+    assert_allclose(x_orig.grad, 2 * np.arange(3.0))

--- a/tests/test_operation_base.py
+++ b/tests/test_operation_base.py
@@ -3,10 +3,12 @@ import numpy as np
 import pytest
 from hypothesis import given
 from hypothesis.extra import numpy as hnp
+from numpy.testing import assert_allclose
 
+import mygrad as mg
 from mygrad import Tensor
 from mygrad.errors import InvalidGradient
-from mygrad.operation_base import Operation
+from mygrad.operation_base import BinaryUfunc, Operation, UnaryUfunc
 from tests.utils import does_not_raise
 
 
@@ -52,3 +54,30 @@ def test_backpropping_non_numeric_gradient_raises(
     # if constant tensor, backprop should not be triggered - no exception raised
     with (pytest.raises(InvalidGradient) if not constant else does_not_raise()):
         x.backward()
+
+
+def test_simple_unary_ufunc_with_where():
+    from mygrad.math.exp_log.ops import Exp
+
+    exp = Exp()
+    mask = np.array([True, False, True])
+    out = exp(mg.zeros((3,)), where=mask)
+    assert_allclose(out[mask], [1.0, 1.0])
+    assert not np.isclose(out[1].item(), 1.0)
+
+
+def test_simple_binary_ufunc_with_where():
+    from mygrad.math.arithmetic.ops import Multiply
+
+    mul = Multiply()
+    mask = np.array([True, False, True])
+    out = mul(mg.ones((3,)), mg.full((3,), 2.0), where=mask)
+    assert_allclose(out[mask], [2.0, 2.0])
+    assert not np.isclose(out[1].item(), 2.0)
+
+
+def test_simple_sequential_func_with_where():
+    from mygrad.math.sequential.ops import Sum
+
+    sum_ = Sum()
+    assert sum_(mg.ones((3,)), where=np.array([True, False, True])).item() == 2.0

--- a/tests/test_ufuncs.py
+++ b/tests/test_ufuncs.py
@@ -13,9 +13,11 @@ def all_subclasses(cls):
     )
 
 
-all_concrete_ufuncs = [
-    ufunc for ufunc in all_subclasses(Ufunc) if not inspect.isabstract(ufunc)
-]
+# names need to be sorted so parallel testing doesn't break
+all_concrete_ufuncs = sorted(
+    (ufunc for ufunc in all_subclasses(Ufunc) if (not inspect.isabstract(ufunc))),
+    key=lambda x: x.__name__,
+)
 
 
 @pytest.mark.parametrize("ufunc", all_concrete_ufuncs)


### PR DESCRIPTION
Implements an ergonomic and intuitive hierarchy of `Operation` subclasses. Among these is the `Ufunc` base class, which permits MyGrad's operations to easily match the interface of numpy's many ufuncs. 

Ultimately, this PR will will enable MyGrad to leverage [the interfaces `__array_ufunc__` and `__array_function__`](https://numpy.org/doc/stable/user/basics.dispatch.html). Additionally, it makes it much easier for MyGrad to support specifying `out`, `where`, and `dtype` on a large majority of its operations.