### PR TITLE
Revise constant=False semantics

### DIFF
--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -370,6 +370,22 @@ It is also now standard to require that this argument be a keyword-only argument
 |                                             |    True                                      |
 +---------------------------------------------+----------------------------------------------+
 
+>>> t1 = mg.tensor(1., constant=True)
+>>> t2 = mg.tensor(1., constant=True)
+
+# old behavior
+>>> out = mg.add(t1, t2, constant=False)
+>>> out.constant
+True
+
+# new behavior
+>>> out = mg.add(t1, t2, constant=False)
+>>> out.constant
+False
+
+>>> out = mg.add(t1, t2, constant=None)
+>>> out.constant
+True
 
 Remove Scalar-Only Conditions on Backpropagation
 ------------------------------------------------

--- a/docs/source/changes.rst
+++ b/docs/source/changes.rst
@@ -332,6 +332,44 @@ for extensive examples of its usage.
 For computations involving many small tensors, this can produce **up to a 3x speedup**! So make sure you
 make keen use of this when you don't actually need to perform autodiff.
 
+Revamping Constant Semantics to be Explicit
+-------------------------------------------
+
+Previously, specifying ``constant=False`` in a mygrad function did not actually mean
+that the function would necessarily produce a non-constant tensor. Rather, it simply
+meant that the output would not be _forced_ to be a constant – whether or not the result
+was a constant depended on the inputs (i.e. a function whose inputs were all constants
+would thus produce a constant).
+
+This was a very bad design decision! Now, specifying ``constant=False`` guarantees that
+the output of a function is a non-constant (meaning that it facilitates backpropagation
+through a computational graph).
+
+That being said, we usually _do_ want constant information to propagate through functions.
+Thus ``constant=None`` is now the default value – its behavior matches that of ``constant=False``
+from MyGrad 1.X – for all functions that accept the argument.
+
+It is also now standard to require that this argument be a keyword-only argument.
+
+
++---------------------------------------------+----------------------------------------------+
+| MyGrad 1.X                                  | MyGrad 2.0                                   |
++=============================================+==============================================+
+| .. code:: python                            | .. code:: python                             |
+|                                             |                                              |
+|    >>> t1 = mg.tensor(1., constant=True)    |    >>> t1 = mg.tensor(1., constant=True)     |
+|    >>> t2 = mg.tensor(1., constant=True)    |    >>> t2 = mg.tensor(1., constant=True)     |
+|                                             |                                              |
+|    >>> out = mg.add(t1, t2, constant=False) |    >>> out = mg.add(t1, t2, constant=False)  |
+|    >>> out.constant                         |    >>> out.constant                          |
+|    True                                     |    False                                     |
+|                                             |                                              |
+|                                             |    # constant = None                         |
+|                                             |    >>> out = mg.add(t1, t2)                  |
+|                                             |    >>> out.constant                          |
+|                                             |    True                                      |
++---------------------------------------------+----------------------------------------------+
+
 
 Remove Scalar-Only Conditions on Backpropagation
 ------------------------------------------------

--- a/src/mygrad/indexing_routines/funcs.py
+++ b/src/mygrad/indexing_routines/funcs.py
@@ -18,7 +18,7 @@ class _UniqueIdentifier:
 not_set = _UniqueIdentifier("not_set")
 
 
-def where(condition, x=not_set, y=not_set, constant=False):
+def where(condition, x=not_set, y=not_set, *, constant=None):
     """
     where(condition, [x, y])
 

--- a/src/mygrad/math/arithmetic/funcs.py
+++ b/src/mygrad/math/arithmetic/funcs.py
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 
-def add(a, b, constant=False):
+def add(a, b, *, constant=None):
     """``f(a, b) -> a + b``
 
     Parameters
@@ -60,7 +60,7 @@ def add(a, b, constant=False):
     return Tensor._op(Add, a, b, constant=constant)
 
 
-def subtract(a, b, constant=False):
+def subtract(a, b, *, constant=None):
     """``f(a, b) -> a - b``
 
     Parameters
@@ -92,7 +92,7 @@ def subtract(a, b, constant=False):
     return Tensor._op(Subtract, a, b, constant=constant)
 
 
-def divide(a, b, constant=False):
+def divide(a, b, *, constant=None):
     """``f(a, b) -> a / b``
 
     Parameters
@@ -111,7 +111,7 @@ def divide(a, b, constant=False):
     return Tensor._op(Divide, a, b, constant=constant)
 
 
-def square(a, constant=False):
+def square(a, *, constant=None):
     """``f(a) -> a ** 2``
 
     Parameters
@@ -128,7 +128,7 @@ def square(a, constant=False):
     return Tensor._op(Square, a, constant=constant)
 
 
-def reciprocal(a, constant=False):
+def reciprocal(a, *, constant=None):
     """``f(a) -> 1 / a``
 
     Parameters
@@ -145,7 +145,7 @@ def reciprocal(a, constant=False):
     return Tensor._op(Reciprocal, a, constant=constant)
 
 
-def power(a, b, constant=False):
+def power(a, b, *, constant=None):
     """``f(a, b) -> a ** b``
 
     Parameters
@@ -164,7 +164,7 @@ def power(a, b, constant=False):
     return Tensor._op(Power, a, b, constant=constant)
 
 
-def multiply(a, b, constant=False):
+def multiply(a, b, *, constant=None):
     """``f(a, b) -> a * b``
 
     Parameters
@@ -183,7 +183,7 @@ def multiply(a, b, constant=False):
     return Tensor._op(Multiply, a, b, constant=constant)
 
 
-def multiply_sequence(*variables, constant=False):
+def multiply_sequence(*variables, constant=None):
     """``f(a, b, ...) -> a * b * ...``
 
     Multiply a sequence of N tensors.
@@ -212,7 +212,7 @@ def multiply_sequence(*variables, constant=False):
     return Tensor._op(MultiplySequence, *variables, constant=constant)
 
 
-def add_sequence(*variables, constant=False):
+def add_sequence(*variables, constant=None):
     """``f(a, b, ...) -> a + b + ...``
 
     Add a sequence of N tensors.
@@ -241,7 +241,7 @@ def add_sequence(*variables, constant=False):
     return Tensor._op(AddSequence, *variables, constant=constant)
 
 
-def positive(a, where=True, constant=False):
+def positive(a, where=True, *, constant=None):
     """``f(a) -> +a``
 
     Creates a new tensor.
@@ -266,7 +266,7 @@ def positive(a, where=True, constant=False):
     return Tensor._op(Positive, a, op_kwargs=(dict(where=where)), constant=constant)
 
 
-def negative(a, where=True, constant=False):
+def negative(a, where=True, *, constant=None):
     """``f(a) -> -a``
 
     Parameters

--- a/src/mygrad/math/exp_log/funcs.py
+++ b/src/mygrad/math/exp_log/funcs.py
@@ -15,7 +15,7 @@ __all__ = [
 ]
 
 
-def exp(a, constant=False):
+def exp(a, *, constant=None):
     """``f(a) -> exp(a)``
 
     Parameters
@@ -32,7 +32,7 @@ def exp(a, constant=False):
     return Tensor._op(Exp, a, constant=constant)
 
 
-def exp2(a, constant=False):
+def exp2(a, *, constant=None):
     """``f(a) -> 2^a``
 
     Parameters
@@ -49,7 +49,7 @@ def exp2(a, constant=False):
     return Tensor._op(Exp2, a, constant=constant)
 
 
-def expm1(a, constant=False):
+def expm1(a, *, constant=None):
     """``f(a) -> exp(a) - 1``
 
     The inverse of ``logp1``.
@@ -73,7 +73,7 @@ def expm1(a, constant=False):
     return Tensor._op(Expm1, a, constant=constant)
 
 
-def logaddexp(a, b, constant=False):
+def logaddexp(a, b, *, constant=None):
     """``f(a, b) -> log(exp(a) + exp(b))``
 
     Parameters
@@ -101,7 +101,7 @@ def logaddexp(a, b, constant=False):
     return Tensor._op(Logaddexp, a, b, constant=constant)
 
 
-def logaddexp2(a, b, constant=False):
+def logaddexp2(a, b, *, constant=None):
     """``f(a, b) -> log_2(2 ** a + 2 ** b)``
 
     Utilizes base-2 log.
@@ -131,7 +131,7 @@ def logaddexp2(a, b, constant=False):
     return Tensor._op(Logaddexp2, a, b, constant=constant)
 
 
-def log(a, constant=False):
+def log(a, *, constant=None):
     """``f(a) -> log(a)``
 
     Natural logarithm
@@ -155,7 +155,7 @@ def log(a, constant=False):
     return Tensor._op(Log, a, constant=constant)
 
 
-def log2(a, constant=False):
+def log2(a, *, constant=None):
     """``f(a) -> log2(a)``
 
     Base-2 logarithm
@@ -174,7 +174,7 @@ def log2(a, constant=False):
     return Tensor._op(Log2, a, constant=constant)
 
 
-def log10(a, constant=False):
+def log10(a, *, constant=None):
     """``f(a) -> log10(a)``
 
     Base-10 logarithm
@@ -193,7 +193,7 @@ def log10(a, constant=False):
     return Tensor._op(Log10, a, constant=constant)
 
 
-def log1p(a, constant=False):
+def log1p(a, *, constant=None):
     """f(a) -> log(1 + a)
 
     The inverse of ``expm1``.

--- a/src/mygrad/math/hyperbolic_trig/funcs.py
+++ b/src/mygrad/math/hyperbolic_trig/funcs.py
@@ -17,7 +17,7 @@ __all__ = [
 ]
 
 
-def arccosh(a, constant=False):
+def arccosh(a, *, constant=None):
     """``f(a) -> arccosh(a)``
 
     Parameters
@@ -34,7 +34,7 @@ def arccosh(a, constant=False):
     return Tensor._op(Arccosh, a, constant=constant)
 
 
-def arccoth(a, constant=False):
+def arccoth(a, *, constant=None):
     """``f(a) -> arccoth(a)``
 
     Parameters
@@ -51,7 +51,7 @@ def arccoth(a, constant=False):
     return Tensor._op(Arccoth, a, constant=constant)
 
 
-def arccsch(a, constant=False):
+def arccsch(a, *, constant=None):
     """``f(a) -> arccsch(a)``
 
     Parameters
@@ -68,7 +68,7 @@ def arccsch(a, constant=False):
     return Tensor._op(Arccsch, a, constant=constant)
 
 
-def arcsinh(a, constant=False):
+def arcsinh(a, *, constant=None):
     """``f(a) -> arcsinh(a)``
 
     Parameters
@@ -85,7 +85,7 @@ def arcsinh(a, constant=False):
     return Tensor._op(Arcsinh, a, constant=constant)
 
 
-def arctanh(a, constant=False):
+def arctanh(a, *, constant=None):
     """``f(a) -> arctanh(a)``
 
     Parameters
@@ -102,7 +102,7 @@ def arctanh(a, constant=False):
     return Tensor._op(Arctanh, a, constant=constant)
 
 
-def cosh(a, constant=False):
+def cosh(a, *, constant=None):
     """``f(a) -> cosh(a)``
 
     Parameters
@@ -119,7 +119,7 @@ def cosh(a, constant=False):
     return Tensor._op(Cosh, a, constant=constant)
 
 
-def coth(a, constant=False):
+def coth(a, *, constant=None):
     """``f(a) -> coth(a)``
 
     Parameters
@@ -136,7 +136,7 @@ def coth(a, constant=False):
     return Tensor._op(Coth, a, constant=constant)
 
 
-def csch(a, constant=False):
+def csch(a, *, constant=None):
     """``f(a) -> csch(a)``
 
     Parameters
@@ -153,7 +153,7 @@ def csch(a, constant=False):
     return Tensor._op(Csch, a, constant=constant)
 
 
-def sech(a, constant=False):
+def sech(a, *, constant=None):
     """``f(a) -> sech(a)``
 
     Parameters
@@ -170,7 +170,7 @@ def sech(a, constant=False):
     return Tensor._op(Sech, a, constant=constant)
 
 
-def sinh(a, constant=False):
+def sinh(a, *, constant=None):
     """``f(a) -> sinh(a)``
 
     Parameters
@@ -187,7 +187,7 @@ def sinh(a, constant=False):
     return Tensor._op(Sinh, a, constant=constant)
 
 
-def tanh(x, constant=False):
+def tanh(x, *, constant=None):
     """``f(x) -> tanh(x)``
 
     Parameters

--- a/src/mygrad/math/misc/funcs.py
+++ b/src/mygrad/math/misc/funcs.py
@@ -5,7 +5,7 @@ from .ops import Abs, Cbrt, Maximum, Minimum, Sqrt
 __all__ = ["abs", "absolute", "cbrt", "clip", "sqrt", "maximum", "minimum"]
 
 
-def abs(a, constant=False):
+def abs(a, *, constant=None):
     """``f(a) -> abs(a)``
 
     Parameters
@@ -29,7 +29,7 @@ def abs(a, constant=False):
 absolute = abs
 
 
-def sqrt(a, constant=False):
+def sqrt(a, *, constant=None):
     """``f(a) -> sqrt(a)``
 
     Parameters
@@ -46,7 +46,7 @@ def sqrt(a, constant=False):
     return Tensor._op(Sqrt, a, constant=constant)
 
 
-def cbrt(a, constant=False):
+def cbrt(a, *, constant=None):
     """``f(a) -> cbrt(a)``
 
     Parameters
@@ -63,7 +63,7 @@ def cbrt(a, constant=False):
     return Tensor._op(Cbrt, a, constant=constant)
 
 
-def maximum(a, b, constant=False):
+def maximum(a, b, *, constant=None):
     """Element-wise maximum of array elements.
 
     Parameters
@@ -87,7 +87,7 @@ def maximum(a, b, constant=False):
     return Tensor._op(Maximum, a, b, constant=constant)
 
 
-def minimum(a, b, constant=False):
+def minimum(a, b, *, constant=None):
     """Element-wise minimum of array elements.
 
     Parameters
@@ -111,7 +111,7 @@ def minimum(a, b, constant=False):
     return Tensor._op(Minimum, a, b, constant=constant)
 
 
-def clip(a, a_min, a_max, constant=False):
+def clip(a, a_min, a_max, *, constant=None):
     """Clip (limit) the values in an array.
 
     Given an interval, values outside the interval are clipped to

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -18,7 +18,7 @@ __all__ = [
 ]
 
 
-def sum(x, axis=None, keepdims=False, constant=False):
+def sum(x, axis=None, keepdims=False, *, constant=None):
     """
     Sum of tensor elements over a given axis.
 
@@ -98,7 +98,7 @@ def sum(x, axis=None, keepdims=False, constant=False):
     )
 
 
-def mean(x, axis=None, keepdims=False, constant=False):
+def mean(x, axis=None, keepdims=False, *, constant=None):
     """
     Mean of tensor elements over a given axis.
 
@@ -162,7 +162,7 @@ def mean(x, axis=None, keepdims=False, constant=False):
     )
 
 
-def var(x, axis=None, ddof=0, keepdims=False, constant=False):
+def var(x, axis=None, ddof=0, keepdims=False, *, constant=None):
     """
     Compute the variance along the specified axis.
 
@@ -245,7 +245,7 @@ def var(x, axis=None, ddof=0, keepdims=False, constant=False):
     )
 
 
-def std(x, axis=None, ddof=0, keepdims=False, constant=False):
+def std(x, axis=None, ddof=0, keepdims=False, *, constant=None):
     """
     Compute the standard deviation along the specified axis.
 
@@ -326,7 +326,7 @@ def std(x, axis=None, ddof=0, keepdims=False, constant=False):
     )
 
 
-def max(x, axis=None, keepdims=False, constant=False):
+def max(x, axis=None, keepdims=False, *, constant=None):
     """
     Return the maximum of a tensor or maximum along its axes.
 
@@ -378,7 +378,7 @@ def max(x, axis=None, keepdims=False, constant=False):
     )
 
 
-def min(x, axis=None, keepdims=False, constant=False):
+def min(x, axis=None, keepdims=False, *, constant=None):
     """
     Return the minimum of a tensor or minimum along its axes.
 
@@ -433,7 +433,7 @@ amin = min
 amax = max
 
 
-def prod(a, axis=None, keepdims=False, constant=False):
+def prod(a, axis=None, keepdims=False, *, constant=None):
     """
     Return the product of array elements over given axes.
 
@@ -487,7 +487,7 @@ def prod(a, axis=None, keepdims=False, constant=False):
     )
 
 
-def cumprod(a, axis=None, constant=False):
+def cumprod(a, axis=None, *, constant=None):
     """
     Return the cumulative product of elements along a given axis.
 
@@ -539,7 +539,7 @@ def cumprod(a, axis=None, constant=False):
     return Tensor._op(CumProd, a, op_kwargs=dict(axis=axis), constant=constant)
 
 
-def cumsum(a, axis=None, constant=False):
+def cumsum(a, axis=None, *, constant=None):
     """
     Return the cumulative sum of the elements along a given axis.
 

--- a/src/mygrad/math/trigonometric/funcs.py
+++ b/src/mygrad/math/trigonometric/funcs.py
@@ -20,7 +20,7 @@ __all__ = [
 ]
 
 
-def sin(a, constant=False):
+def sin(a, *, constant=None):
     """``f(a) -> sin(a)``
 
     Parameters
@@ -37,7 +37,7 @@ def sin(a, constant=False):
     return Tensor._op(Sin, a, constant=constant)
 
 
-def sinc(a, constant=False):
+def sinc(a, *, constant=None):
     """``f(a) -> sin(a) / a``
 
     Parameters
@@ -54,7 +54,7 @@ def sinc(a, constant=False):
     return Tensor._op(Sinc, a, constant=constant)
 
 
-def cos(a, constant=False):
+def cos(a, *, constant=None):
     """``f(a) -> cos(a)``
 
     Parameters
@@ -71,7 +71,7 @@ def cos(a, constant=False):
     return Tensor._op(Cos, a, constant=constant)
 
 
-def tan(a, constant=False):
+def tan(a, *, constant=None):
     """``f(a) -> tan(a)``
 
     Parameters
@@ -88,7 +88,7 @@ def tan(a, constant=False):
     return Tensor._op(Tan, a, constant=constant)
 
 
-def cot(a, constant=False):
+def cot(a, *, constant=None):
     """``f(a) -> cot(a)``
 
     Parameters
@@ -105,7 +105,7 @@ def cot(a, constant=False):
     return Tensor._op(Cot, a, constant=constant)
 
 
-def csc(a, constant=False):
+def csc(a, *, constant=None):
     """``f(a) -> csc(a)``
 
     Parameters
@@ -122,7 +122,7 @@ def csc(a, constant=False):
     return Tensor._op(Csc, a, constant=constant)
 
 
-def sec(a, constant=False):
+def sec(a, *, constant=None):
     """``f(a) -> sec(a)``
 
     Parameters
@@ -139,7 +139,7 @@ def sec(a, constant=False):
     return Tensor._op(Sec, a, constant=constant)
 
 
-def arccos(a, constant=False):
+def arccos(a, *, constant=None):
     """``f(a) -> arccos(a)``
 
     Parameters
@@ -156,7 +156,7 @@ def arccos(a, constant=False):
     return Tensor._op(Arccos, a, constant=constant)
 
 
-def arccsc(a, constant=False):
+def arccsc(a, *, constant=None):
     """``f(a) -> arccsc(a)``
 
     Parameters
@@ -173,7 +173,7 @@ def arccsc(a, constant=False):
     return Tensor._op(Arccsc, a, constant=constant)
 
 
-def arccot(a, constant=False):
+def arccot(a, *, constant=None):
     """``f(a) -> arccot(a)``
 
     Parameters
@@ -190,7 +190,7 @@ def arccot(a, constant=False):
     return Tensor._op(Arccot, a, constant=constant)
 
 
-def arcsin(a, constant=False):
+def arcsin(a, *, constant=None):
     """``f(a) -> arctanh(a)``
 
     Parameters
@@ -207,7 +207,7 @@ def arcsin(a, constant=False):
     return Tensor._op(Arcsin, a, constant=constant)
 
 
-def arctan(a, constant=False):
+def arctan(a, *, constant=None):
     """``f(a) -> arctan(a)``
 
     Parameters
@@ -224,7 +224,7 @@ def arctan(a, constant=False):
     return Tensor._op(Arctan, a, constant=constant)
 
 
-def arcsec(a, constant=False):
+def arcsec(a, *, constant=None):
     """``f(a) -> arcsec(a)``
 
     Parameters
@@ -241,7 +241,7 @@ def arcsec(a, constant=False):
     return Tensor._op(Arcsec, a, constant=constant)
 
 
-def arctan2(a, b, constant=False):
+def arctan2(a, b, *, constant=None):
     """``f(a, b) -> arctan(a/b)``
 
     Parameters

--- a/src/mygrad/nnet/activations/elu.py
+++ b/src/mygrad/nnet/activations/elu.py
@@ -41,7 +41,7 @@ class ELU(Operation):
         return grad * np.where(x.data < 0, self.exp + self.alpha, 1)
 
 
-def elu(x, alpha, constant=False):
+def elu(x, alpha, *, constant=None):
     """Returns the exponential linear activation (ELU) elementwise along x.
 
     The ELU is given by  `ɑ(exp(x) - 1) for x < 0 and x for x ≥ 0`.

--- a/src/mygrad/nnet/activations/glu.py
+++ b/src/mygrad/nnet/activations/glu.py
@@ -5,7 +5,7 @@ from mygrad import Tensor, multiply
 from .sigmoid import sigmoid
 
 
-def glu(x, axis=-1, constant=False):
+def glu(x, axis=-1, *, constant=None):
     """Returns the Gated Linear Unit A * σ(B), where A and B are split from `x`.
 
     Parameters

--- a/src/mygrad/nnet/activations/hard_tanh.py
+++ b/src/mygrad/nnet/activations/hard_tanh.py
@@ -8,7 +8,7 @@ from mygrad.tensor_base import Tensor
 __all__ = ["hard_tanh"]
 
 
-def hard_tanh(x, *, lower_bound=-1, upper_bound=1, constant=False):
+def hard_tanh(x, *, lower_bound=-1, upper_bound=1, constant=None):
     """Returns the hard hyperbolic tangent function.
 
     The hard_tanh function is `lower_bound` where `x` <= `lower_bound`, `upper_bound` where

--- a/src/mygrad/nnet/activations/leaky_relu.py
+++ b/src/mygrad/nnet/activations/leaky_relu.py
@@ -8,7 +8,7 @@ from mygrad.tensor_base import Tensor
 __all__ = ["leaky_relu"]
 
 
-def leaky_relu(x, slope, constant=False):
+def leaky_relu(x, slope, *, constant=None):
     """Returns the leaky rectified linear activation elementwise along x.
 
     The leaky ReLU is given by `max(x, 0) + slope*min(x, 0)`.

--- a/src/mygrad/nnet/activations/relu.py
+++ b/src/mygrad/nnet/activations/relu.py
@@ -14,7 +14,7 @@ class ReLu(Operation):
         return grad * self.back
 
 
-def relu(x, constant=False):
+def relu(x, *, constant=None):
     """
     Applies the recitfied linear unit activation function::
 

--- a/src/mygrad/nnet/activations/selu.py
+++ b/src/mygrad/nnet/activations/selu.py
@@ -45,7 +45,7 @@ class SELU(Operation):
         return grad * _SCALE * np.where(x.data < 0, self.exp + _ALPHA, 1)
 
 
-def selu(x, constant=False):
+def selu(x, *, constant=None):
     """Returns the scaled exponential linear activation (SELU) elementwise along x.
 
     The SELU is given by  λɑ(exp(x) - 1) for x < 0 and λx for x ≥ 0.

--- a/src/mygrad/nnet/activations/sigmoid.py
+++ b/src/mygrad/nnet/activations/sigmoid.py
@@ -18,7 +18,7 @@ class Sigmoid(Operation):
         return grad * self.sigmoid * (1.0 - self.sigmoid)
 
 
-def sigmoid(x, constant=False):
+def sigmoid(x, *, constant=None):
     """Applies the sigmoid activation function::
 
       f(x) = 1 / (1 + exp(-x))

--- a/src/mygrad/nnet/activations/soft_sign.py
+++ b/src/mygrad/nnet/activations/soft_sign.py
@@ -3,7 +3,7 @@ from mygrad import abs, divide
 __all__ = ["soft_sign"]
 
 
-def soft_sign(x, constant=False):
+def soft_sign(x, *, constant=None):
     """Returns the soft sign function x / (1 + |x|).
 
     Parameters

--- a/src/mygrad/nnet/activations/softmax.py
+++ b/src/mygrad/nnet/activations/softmax.py
@@ -35,7 +35,7 @@ class Softmax(Operation):
         return sg - soft * np.sum(sg, **self._kw)
 
 
-def softmax(x, axis=-1, constant=False):
+def softmax(x, axis=-1, *, constant=None):
     r"""
     Applies the softmax activation function::
 
@@ -104,7 +104,7 @@ class LogSoftmax(Operation):
         return grad - soft * np.sum(grad, **self._kw)
 
 
-def logsoftmax(x, axis=-1, constant=False):
+def logsoftmax(x, axis=-1, *, constant=None):
     r"""
     Applies the log-softmax activation function::
 

--- a/src/mygrad/nnet/initializers/constant.py
+++ b/src/mygrad/nnet/initializers/constant.py
@@ -1,7 +1,7 @@
 from mygrad.tensor_creation.funcs import full
 
 
-def constant(*shape, value=0.0, dtype=None, constant=False):
+def constant(*shape, value=0.0, dtype=None, constant=None):
     """Initialize a `Tensor` of shape `shape` with a constant value.
 
     This function is a thin wrapper around `mygrad.full`.

--- a/src/mygrad/nnet/initializers/glorot_normal.py
+++ b/src/mygrad/nnet/initializers/glorot_normal.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad import Tensor
 
 
-def glorot_normal(*shape, gain=1, dtype=np.float32, constant=False):
+def glorot_normal(*shape, gain=1, dtype=np.float32, constant=None):
     r"""Initialize a `Tensor` according to the normal initialization procedure
     described by Glorot and Bengio.
 

--- a/src/mygrad/nnet/initializers/glorot_uniform.py
+++ b/src/mygrad/nnet/initializers/glorot_uniform.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad.nnet.initializers.uniform import uniform
 
 
-def glorot_uniform(*shape, gain=1, dtype=np.float32, constant=False):
+def glorot_uniform(*shape, gain=1, dtype=np.float32, constant=None):
     r"""Initialize a `Tensor` according to the uniform initialization procedure
     described by Glorot and Bengio.
 

--- a/src/mygrad/nnet/initializers/he_normal.py
+++ b/src/mygrad/nnet/initializers/he_normal.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad.nnet.initializers.normal import normal
 
 
-def he_normal(*shape, gain=1, dtype=np.float32, constant=False):
+def he_normal(*shape, gain=1, dtype=np.float32, constant=None):
     r"""Initialize a ``Tensor`` according to the normal initialization procedure
     described by He et al.
 

--- a/src/mygrad/nnet/initializers/he_uniform.py
+++ b/src/mygrad/nnet/initializers/he_uniform.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad.nnet.initializers.uniform import uniform
 
 
-def he_uniform(*shape, gain=1, dtype=np.float32, constant=False):
+def he_uniform(*shape, gain=1, dtype=np.float32, constant=None):
     r"""Initialize a ``mygrad.Tensor`` according to the uniform initialization procedure
     described by He et al.
 

--- a/src/mygrad/nnet/initializers/normal.py
+++ b/src/mygrad/nnet/initializers/normal.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad import Tensor
 
 
-def normal(*shape, mean=0, std=1, dtype=np.float32, constant=False):
+def normal(*shape, mean=0, std=1, dtype=np.float32, constant=None):
     """Initialize a :class:`mygrad.Tensor` by drawing from a normal (Gaussian) distribution.
 
     Parameters

--- a/src/mygrad/nnet/initializers/uniform.py
+++ b/src/mygrad/nnet/initializers/uniform.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad import Tensor
 
 
-def uniform(*shape, lower_bound=0, upper_bound=1, dtype=np.float32, constant=False):
+def uniform(*shape, lower_bound=0, upper_bound=1, dtype=np.float32, constant=None):
     """Initialize a ``Tensor`` by drawing from a uniform distribution.
 
     Parameters

--- a/src/mygrad/nnet/layers/batchnorm.py
+++ b/src/mygrad/nnet/layers/batchnorm.py
@@ -108,7 +108,7 @@ class BatchNorm(Operation):
             raise IndexError
 
 
-def batchnorm(x, *, gamma=None, beta=None, eps, constant=False):
+def batchnorm(x, *, gamma=None, beta=None, eps, constant=None):
     """
     Performs batch normalization on ``x``::
 

--- a/src/mygrad/nnet/layers/conv.py
+++ b/src/mygrad/nnet/layers/conv.py
@@ -153,7 +153,7 @@ class ConvND(Operation):
             return np.tensordot(grad, windowed_data, axes=[grad_axes, window_axes])
 
 
-def conv_nd(x, filter_bank, *, stride, padding=0, dilation=1, constant=False):
+def conv_nd(x, filter_bank, *, stride, padding=0, dilation=1, constant=None):
     """Use `filter_bank` to perform strided N-dimensional neural network-style
     convolutions (see Notes) over `x`.::
 

--- a/src/mygrad/nnet/layers/gru.py
+++ b/src/mygrad/nnet/layers/gru.py
@@ -435,7 +435,7 @@ def gru(
     s0=None,
     bp_lim=None,
     dropout=0.0,
-    constant=False,
+    constant=None,
 ):
     r"""Performs a forward pass of sequential data through a Gated Recurrent Unit layer, returning
     the 'hidden-descriptors' arrived at by utilizing the trainable parameters as follows::

--- a/src/mygrad/nnet/layers/pooling.py
+++ b/src/mygrad/nnet/layers/pooling.py
@@ -147,7 +147,7 @@ class MaxPoolND(Operation):
         return dx.reshape(x.shape)
 
 
-def max_pool(x, pool, stride, constant=False):
+def max_pool(x, pool, stride, *, constant=None):
     """Perform max-pooling over the last N dimensions of a data batch.
 
     Extended Summary

--- a/src/mygrad/nnet/losses/focal_loss.py
+++ b/src/mygrad/nnet/losses/focal_loss.py
@@ -103,7 +103,7 @@ class FocalLoss(Operation):
         return self.back
 
 
-def focal_loss(class_probs, targets, *, alpha=1, gamma=0, constant=False):
+def focal_loss(class_probs, targets, *, alpha=1, gamma=0, constant=None):
     r"""Return the per-datum focal loss.
 
     Parameters
@@ -156,7 +156,7 @@ def focal_loss(class_probs, targets, *, alpha=1, gamma=0, constant=False):
     )
 
 
-def softmax_focal_loss(scores, targets, *, alpha=1, gamma=0, constant=False):
+def softmax_focal_loss(scores, targets, *, alpha=1, gamma=0, constant=None):
     r"""
     Applies the softmax normalization to the input scores before computing the
     per-datum focal loss.

--- a/src/mygrad/nnet/losses/margin_ranking_loss.py
+++ b/src/mygrad/nnet/losses/margin_ranking_loss.py
@@ -47,7 +47,7 @@ class MarginRanking(Operation):
         return grad * (sign * self._grad)
 
 
-def margin_ranking_loss(x1, x2, y, margin, constant=False):
+def margin_ranking_loss(x1, x2, y, margin, *, constant=None):
     r"""Computes the margin average margin ranking loss.
     Equivalent to::
 

--- a/src/mygrad/nnet/losses/multiclass_hinge.py
+++ b/src/mygrad/nnet/losses/multiclass_hinge.py
@@ -56,7 +56,7 @@ class MulticlassHinge(Operation):
         return grad * self.back
 
 
-def multiclass_hinge(x, y_true, hinge=1.0, constant=False):
+def multiclass_hinge(x, y_true, hinge=1.0, *, constant=None):
     """Computes the average multiclass hinge loss.
 
     Parameters

--- a/src/mygrad/nnet/losses/negative_log_likelihood.py
+++ b/src/mygrad/nnet/losses/negative_log_likelihood.py
@@ -5,7 +5,7 @@ from mygrad import Tensor, asarray, mean
 from ._utils import check_loss_inputs
 
 
-def negative_log_likelihood(x, y_true, *, weights=None, constant=False):
+def negative_log_likelihood(x, y_true, *, weights=None, constant=None):
     """Returns the (weighted) negative log-likelihood loss between log-probabilities and y_true.
 
     Note that this does not compute a softmax, so you should input log-probabilities to this.

--- a/src/mygrad/nnet/losses/softmax_crossentropy.py
+++ b/src/mygrad/nnet/losses/softmax_crossentropy.py
@@ -47,7 +47,7 @@ class SoftmaxCrossEntropy(Operation):
         return grad * self.back
 
 
-def softmax_crossentropy(x, y_true, constant=False):
+def softmax_crossentropy(x, y_true, *, constant=None):
     r"""Given the classification scores of C classes for N pieces of data,
 
     computes the NxC softmax classification probabilities. The

--- a/src/mygrad/random/funcs.py
+++ b/src/mygrad/random/funcs.py
@@ -3,7 +3,7 @@ import numpy as np
 from mygrad import Tensor
 
 
-def rand(*shape, constant=False):
+def rand(*shape, constant=None):
     """Create a Tensor of the given shape and populate it with random
     samples from a uniform distribution over [0, 1).
 
@@ -78,7 +78,7 @@ def randint(low, high=None, shape=None, dtype=int):
     return Tensor(np.random.randint(low, high, shape, dtype), copy=False)
 
 
-def randn(*shape, constant=False):
+def randn(*shape, constant=None):
     """Return a sample (or samples) from the “standard normal” distribution.
 
     Parameters
@@ -117,7 +117,7 @@ def randn(*shape, constant=False):
     return Tensor(np.random.randn(*shape), constant=constant, copy=False)
 
 
-def random(shape=None, constant=False):
+def random(shape=None, *, constant=None):
     """Return random floats in the half-open interval [0.0, 1.0).
 
     To create a random sample of a given shape on the interval [a, b), call
@@ -150,7 +150,7 @@ def random(shape=None, constant=False):
     return Tensor(np.random.random(shape), constant=constant, copy=False)
 
 
-def random_sample(shape=None, constant=False):
+def random_sample(shape=None, *, constant=None):
     """Return random floats in the half-open interval [0.0, 1.0).
 
     Results are from the “continuous uniform” distribution over the stated interval.
@@ -189,7 +189,7 @@ def random_sample(shape=None, constant=False):
     return Tensor(np.random.random_sample(shape), constant=constant, copy=False)
 
 
-def ranf(shape=None, constant=False):
+def ranf(shape=None, *, constant=None):
     """Return random floats in the half-open interval [0.0, 1.0).
 
     To create a random sample of a given shape on the interval [a, b), call
@@ -230,7 +230,7 @@ def ranf(shape=None, constant=False):
     return Tensor(np.random.ranf(shape), constant=constant, copy=False)
 
 
-def sample(shape=None, constant=False):
+def sample(shape=None, *, constant=None):
     """Return random floats in the half-open interval [0.0, 1.0).
 
     To create a random sample of a given shape on the interval [a, b), call

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -725,7 +725,7 @@ class Tensor:
         *input_vars: ArrayLike,
         op_args: Optional[Sequence] = None,
         op_kwargs: Optional[Dict[str, Any]] = None,
-        constant: bool = False,
+        constant: bool = None,
         out: Optional[Union[np.ndarray, "Tensor"]] = None,
     ):
         """Wraps operations performed between tensors: f(a, b, ...).
@@ -863,7 +863,11 @@ class Tensor:
             f.replay_force_constant = constant
 
         # record graph information
-        is_const = constant or all(var.constant for var in tensor_vars)
+        if constant is None:
+            if any(not var.constant for var in tensor_vars):
+                constant = None
+            else:
+                constant = True
 
         # record that a variable participated in that op
         ref_f = ReferenceType(f)  # type: WeakRef[Operation]
@@ -872,7 +876,7 @@ class Tensor:
 
         out = cls(
             op_out,
-            constant=is_const,
+            constant=constant,
             copy=False,
             _creator=f,
             _base=base,
@@ -1257,7 +1261,7 @@ class Tensor:
         *input_vars: ArrayLike,
         op_args: Optional[Sequence] = None,
         op_kwargs: Optional[Dict] = None,
-        constant: bool = False,
+        constant: bool = None,
     ):
         if _track.TRACK_GRAPH is False:
             return self._op(
@@ -1919,7 +1923,7 @@ class Tensor:
         <type 'numpy.dtype'>"""
         return self.data.dtype
 
-    def reshape(self, *newshape: Union[int, Shape], constant: bool = False) -> "Tensor":
+    def reshape(self, *newshape: Union[int, Shape], constant: bool = None) -> "Tensor":
         """Returns a tensor with a new shape, without changing its data.
         This docstring was adapted from ``numpy.reshape``
 

--- a/src/mygrad/tensor_manip/array_shape/funcs.py
+++ b/src/mygrad/tensor_manip/array_shape/funcs.py
@@ -5,7 +5,7 @@ from .ops import *
 __all__ = ["reshape", "squeeze", "ravel", "expand_dims", "broadcast_to"]
 
 
-def reshape(a, newshape, constant=False):
+def reshape(a, newshape, *, constant=None):
     """Returns a tensor with a new shape, without changing its data.
 
     This docstring was adapted from ``numpy.reshape``
@@ -50,7 +50,7 @@ def reshape(a, newshape, constant=False):
     return Tensor._op(Reshape, a, op_args=(newshape,), constant=constant)
 
 
-def squeeze(a, axis=None, constant=False):
+def squeeze(a, axis=None, *, constant=None):
     """
     Remove single-dimensional entries from the shape of a tensor.
 
@@ -98,7 +98,7 @@ def squeeze(a, axis=None, constant=False):
     return Tensor._op(Squeeze, a, op_args=(axis,), constant=constant)
 
 
-def ravel(a, constant=False):
+def ravel(a, *, constant=None):
     """
     Flattens contents of a tensor into a contiguous 1-D array.  A copy is made only if needed.
 
@@ -134,7 +134,7 @@ def ravel(a, constant=False):
     return Tensor._op(Ravel, a, constant=constant)
 
 
-def expand_dims(a, axis, constant=False):
+def expand_dims(a, axis, *, constant=None):
     """
     Expand the dimensions of a tensor by adding a new axis.
 
@@ -172,7 +172,7 @@ def expand_dims(a, axis, constant=False):
     return Tensor._op(ExpandDims, a, op_args=(axis,), constant=constant)
 
 
-def broadcast_to(a, shape, constant=False):
+def broadcast_to(a, shape, *, constant=None):
     """
     Broadcast a tensor to a new shape.
 

--- a/src/mygrad/tensor_manip/tiling/funcs.py
+++ b/src/mygrad/tensor_manip/tiling/funcs.py
@@ -11,7 +11,8 @@ def repeat(
     a,
     repeats: Union[int, Sequence[int]],
     axis: Optional[int] = None,
-    constant: bool = False,
+    *,
+    constant: bool = None,
 ) -> Tensor:
     """
     Repeat elements of a tensor.

--- a/src/mygrad/tensor_manip/transpose_like/funcs.py
+++ b/src/mygrad/tensor_manip/transpose_like/funcs.py
@@ -5,7 +5,7 @@ from .ops import MoveAxis, Roll, SwapAxes, Transpose
 __all__ = ["transpose", "moveaxis", "swapaxes", "roll"]
 
 
-def transpose(a, *axes, constant=False):
+def transpose(a, *axes, constant=None):
     """Permute the dimensions of a tensor.
 
     Parameters
@@ -49,7 +49,7 @@ def transpose(a, *axes, constant=False):
     return Tensor._op(Transpose, a, op_args=(axes,), constant=constant)
 
 
-def moveaxis(a, source, destination, constant=False):
+def moveaxis(a, source, destination, *, constant=None):
     """Move axes of a tensor to new positions. Other axes remain in their
     original order.
 
@@ -88,7 +88,7 @@ def moveaxis(a, source, destination, constant=False):
     return Tensor._op(MoveAxis, a, op_args=(source, destination), constant=constant)
 
 
-def swapaxes(a, axis1, axis2, constant=False):
+def swapaxes(a, axis1, axis2, *, constant=None):
     """Interchange two axes of a tensor.
 
     Parameters
@@ -133,7 +133,7 @@ def swapaxes(a, axis1, axis2, constant=False):
     return Tensor._op(SwapAxes, a, op_args=(axis1, axis2), constant=constant)
 
 
-def roll(a, shift, axis=None, constant=False):
+def roll(a, shift, axis=None, *, constant=None):
     """
     Roll tensor elements along a given axis.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,6 @@ def raise_on_mem_locking_state_leakage() -> bool:
             f"\narr-counter{lock._array_counter}"
         )
         # coverage mode seems to mess with mem-guard synchronization
-        assert COVERAGE_MODE
+        # assert COVERAGE_MODE
 
     clear_all_mem_locking_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,6 @@ def raise_on_mem_locking_state_leakage() -> bool:
             f"\narr-counter{lock._array_counter}"
         )
         # coverage mode seems to mess with mem-guard synchronization
-        # assert COVERAGE_MODE
+        assert COVERAGE_MODE
 
     clear_all_mem_locking_state()

--- a/tests/linalg/test_multi_matmul.py
+++ b/tests/linalg/test_multi_matmul.py
@@ -11,8 +11,8 @@ import mygrad as mg
 from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
-def matmul_wrapper(*args, constant=False):
-    return mg.multi_matmul(args, constant)
+def matmul_wrapper(*args, constant=None):
+    return mg.multi_matmul(args, constant=constant)
 
 
 def multi_matmul_slow(*arrays, **kwargs):

--- a/tests/math/binary/test_binary_funcs.py
+++ b/tests/math/binary/test_binary_funcs.py
@@ -10,7 +10,6 @@ import pytest
 from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
-import mygrad as mg
 from mygrad import (
     add,
     arctan2,
@@ -22,6 +21,7 @@ from mygrad import (
     subtract,
 )
 from tests.custom_strategies import tensors
+from tests.utils import adds_constant_arg
 
 from ...wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
@@ -47,10 +47,7 @@ def inplace_op(inplace_target, other, constant=False, *, op_name: str):
     if isinstance(inplace_target, Number):
         inplace_target = np.asarray(inplace_target)
 
-    getattr(inplace_target, op_name)(other)
-
-    if isinstance(inplace_target, mg.Tensor) and constant:
-        inplace_target._constant = constant
+    adds_constant_arg(getattr(inplace_target, op_name))(other, constant=constant)
 
     return inplace_target
 

--- a/tests/state_testing/test_simple_graph_state.py
+++ b/tests/state_testing/test_simple_graph_state.py
@@ -54,7 +54,7 @@ class GraphCompare(RuleBasedStateMachine):
         a=nodes,
         b=nodes,
         op=st.sampled_from(["add", "multiply"]),
-        constant=st.booleans(),
+        constant=st.sampled_from([True, None]),
     )
     def fuse_nodes(self, a, b, op, constant):
         """
@@ -64,7 +64,10 @@ class GraphCompare(RuleBasedStateMachine):
         n_b, t_b = b  # type: Node, Tensor
         n_op = self.str_to_node_op[op]
         t_op = self.str_to_tensor_op[op]
-        out = (n_op(n_a, n_b, constant=constant), t_op(t_a, t_b, constant=constant))
+        out = (
+            n_op(n_a, n_b, constant=bool(constant)),
+            t_op(t_a, t_b, constant=constant),
+        )
         self.node_list.append(out)
         return out
 

--- a/tests/tensor_base/test_pow_special_cases.py
+++ b/tests/tensor_base/test_pow_special_cases.py
@@ -9,24 +9,20 @@ from hypothesis import given
 import mygrad as mg
 from mygrad.math.arithmetic.ops import Positive, Square
 from tests.custom_strategies import tensors
+from tests.utils import adds_constant_arg, expected_constant
 
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
-hnp.mutually_broadcastable_shapes
+
+@adds_constant_arg
+def custom_pow(x, p):
+    return x ** p
 
 
-def custom_pow(x, p, constant=False):
-    out = x ** p
-    if isinstance(out, mg.Tensor) and constant:
-        out._constant = constant
-    return out
-
-
-def in_place_custom_pow(x, p, constant=False):
+@adds_constant_arg
+def in_place_custom_pow(x, p):
     out = +x
     out **= p
-    if isinstance(out, mg.Tensor) and constant:
-        out._constant = constant
     return out
 
 

--- a/tests/tensor_ops/test_getitem.py
+++ b/tests/tensor_ops/test_getitem.py
@@ -4,6 +4,7 @@ from hypothesis import given, settings
 from numpy.testing import assert_allclose
 
 from mygrad.tensor_base import Tensor
+from tests.utils import adds_constant_arg
 
 from ..custom_strategies import (
     adv_integer_index,
@@ -37,12 +38,9 @@ def test_get_item_propagate_constant(x: Tensor):
     assert y.constant is x.constant
 
 
-def get_item(arr, index, constant=False):
-    o = arr[index]
-    if isinstance(o, Tensor) and constant:
-        o._constant = constant
-
-    return o
+@adds_constant_arg
+def get_item(arr, index):
+    return arr[index]
 
 
 def basic_index_wrap(*arrs):

--- a/tests/tensor_ops/test_iter.py
+++ b/tests/tensor_ops/test_iter.py
@@ -3,6 +3,7 @@ import numpy as np
 import pytest
 
 from mygrad.tensor_base import Tensor
+from tests.utils import adds_constant_arg
 
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
@@ -14,15 +15,14 @@ def test_iter_over_0d_raises():
         sum(x)
 
 
-def _sum(x, constant=False):
+@adds_constant_arg
+def _sum(x):
     out = sum(x)
     if isinstance(x, Tensor):
         if not isinstance(out, Tensor):
             # Hack to deal with summing over an empty tensor.
             # `sum(Tensor([]))` returns 0, which is fine
-            out = Tensor(float(out), constant=constant or x.constant)
-        if constant:
-            out._constant = constant
+            out = Tensor(float(out))
     else:
         out = np.asarray(out)  # ensure numpy-output is array
     return out

--- a/tests/test_constant_inference.py
+++ b/tests/test_constant_inference.py
@@ -1,0 +1,31 @@
+import hypothesis.strategies as st
+import numpy as np
+from hypothesis import given
+
+import mygrad as mg
+from mygrad.math.arithmetic.ops import Multiply
+from tests import populate_args
+from tests.custom_strategies import array_likes, valid_constant_arg
+from tests.utils import clears_mem_state, expected_constant
+
+
+def mul(x, y, *, dtype=None, constant=None):
+    return mg.Tensor._op(Multiply, x, y, op_kwargs=dict(dtype=dtype), constant=constant)
+
+
+@clears_mem_state
+@given(
+    x=array_likes(shape=(1,), dtype=np.int32),
+    y=array_likes(shape=(1,), dtype=np.int32),
+    dtype=st.none() | st.just("float32") | st.just(int),
+    data=st.data(),
+)
+def test_that_typical_op_propagates_constant_under_general_conditions(
+    x, y, dtype, data: st.DataObject
+):
+    arr = np.multiply(x, y, dtype=dtype)
+    constant = data.draw(valid_constant_arg(arr.dtype), label="constant")
+    expected = expected_constant(x, y, dest_dtype=arr.dtype, constant=constant)
+
+    out = mul(x, y, **populate_args(dtype=dtype, constant=constant).kwargs)
+    assert out.constant is expected

--- a/tests/test_indexing_routines.py
+++ b/tests/test_indexing_routines.py
@@ -9,7 +9,7 @@ from mygrad import where
 from tests.wrappers.uber import backprop_test_factory, fwdprop_test_factory
 
 
-def mygrad_where(x, y, condition, constant=False):
+def mygrad_where(x, y, condition, constant=None):
     return where(condition, x, y, constant=constant)
 
 

--- a/tests/test_tensor_creation.py
+++ b/tests/test_tensor_creation.py
@@ -57,6 +57,7 @@ def clamp(val, min_=0.1):
         (logspace, np.logspace),
     ],
 )
+@settings(max_examples=200)
 @given(
     start=st.just(_NoValue) | st.integers(min_value=-10, max_value=10),
     stop=st.integers(min_value=-10, max_value=10),
@@ -95,7 +96,7 @@ def test_arange_like_against_numpy_equivalent(
     except (ZeroDivisionError, TypeError) as e:
         with pytest.raises(type(e)):
             mygrad_func(*inputs.args, **inputs.kwargs)
-        assume(False)
+        return
 
     constant = data.draw(valid_constant_arg(array.dtype), label="constant")
     tensor = mygrad_func(*inputs.args, **inputs.kwargs, constant=constant)
@@ -161,8 +162,8 @@ def test_tensor_create_like_against_numpy_equivalent(
     array = numpy_func(*inputs.args, **inputs.kwargs)
 
     constant = data.draw(valid_constant_arg(array.dtype), label="constant")
-
     tensor = mygrad_func(*inputs.args, **inputs.kwargs, constant=constant)
+
     if numpy_func is not np.empty_like:
         assert_array_equal(tensor, array)
     assert tensor.dtype == array.dtype

--- a/tests/test_tensor_manip.py
+++ b/tests/test_tensor_manip.py
@@ -19,6 +19,7 @@ from mygrad import (
     swapaxes,
     transpose,
 )
+from tests.utils import adds_constant_arg
 
 from .custom_strategies import valid_axes
 from .utils.numerical_gradient import numerical_gradient_full
@@ -180,14 +181,11 @@ def _np_transpose(x, axes):
     return np.transpose(x, axes)
 
 
-def _transpose_property(x, constant=False):
+@adds_constant_arg
+def _transpose_property(x):
     if not isinstance(x, Tensor):
         x = np.asarray(x)
-
-    y = x.T
-    if isinstance(x, Tensor):
-        y._constant = constant or x.constant
-    return y
+    return x.T
 
 
 @fwdprop_test_factory(

--- a/tests/test_view_semantics.py
+++ b/tests/test_view_semantics.py
@@ -122,7 +122,7 @@ def test_tensor_base_matches_ndarray_base(constant: bool):
 @pytest.mark.parametrize("constant", [True, False])
 def test_views_of_non_arrays_leave_no_base(constant: bool):
     assert mg.reshape(2.0, (1,), constant=constant).base is None
-    assert mg.reshape(list(range(9)), (3, 3), constant=constant).base is None
+    assert mg.reshape(np.arange(9.0).tolist(), (3, 3), constant=constant).base is None
 
 
 @pytest.mark.parametrize("constant", [True, False])

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -13,6 +13,22 @@ class InternalTestError(Exception):
     """Marks errors that are caused by bad test configurations"""
 
 
+def adds_constant_arg(func):
+    """Compatibility shim so that functions that do not take a `constant`
+    kwarg can be tested by the testing fixtures that require them to."""
+
+    @wraps(func)
+    def wrapper(*args, constant=None, **kwargs):
+        out = func(*args, **kwargs)
+        if isinstance(out, Tensor):
+            out._constant = expected_constant(
+                args, dest_dtype=out.dtype, constant=constant
+            )
+        return out
+
+    return wrapper
+
+
 def check_dtype_consistency(out: ArrayLike, dest_dtype: DTypeLike):
     if dest_dtype is None:
         return

--- a/tests/wrappers/test_uber.py
+++ b/tests/wrappers/test_uber.py
@@ -38,7 +38,7 @@ def test_arr_from_kwargs(args_as_kwargs):
     KWARG1.passed = False
     arrs_from_kwargs = {name_to_pos[k]: k for k in args_as_kwargs if k != "kwarg1"}
 
-    def sentinel(a, b, c, kwarg1=None):
+    def sentinel(a, b, c, kwarg1=None, *, constant=None):
         assert_allclose(
             np.real(a if isinstance(a, np.ndarray) else a.data),
             expected_a,


### PR DESCRIPTION
Previously, specifying ``constant=False`` in a mygrad function did not actually mean that the function would necessarily produce a non-constant tensor. Rather, it simply meant that the output would not be _forced_ to be a constant – whether or not the result was a constant depended on the inputs (i.e. a function whose inputs were all constants would thus produce a constant).

This was a very bad design decision! Now, specifying ``constant=False`` guarantees that the output of a function is a non-constant (meaning that it facilitates backpropagation through a computational graph).

That being said, we usually _do_ want constant information to propagate through functions. Thus ``constant=None`` is now the default value – its behavior matches that of ``constant=False`` from MyGrad 1.X – for all functions that accept the argument.

It is also now standard to require that this argument be a keyword-only argument.


```python
>>> t1 = mg.tensor(1., constant=True)
>>> t2 = mg.tensor(1., constant=True)

# old behavior
>>> out = mg.add(t1, t2, constant=False)
>>> out.constant        
True    

# new behavior
>>> out = mg.add(t1, t2, constant=False)
>>> out.constant        
False

>>> out = mg.add(t1, t2, constant=None)
>>> out.constant        
True

```

