### PR TITLE
add __array_function__ implementation 

### DIFF
--- a/src/mygrad/indexing_routines/funcs.py
+++ b/src/mygrad/indexing_routines/funcs.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 import numpy as np
 
-from mygrad import Tensor, asarray
 from mygrad.operation_base import _NoValue
+from mygrad.tensor_base import Tensor, asarray, implements_numpy_override
 from mygrad.typing import ArrayLike
 
 from .ops import Where
@@ -11,6 +11,7 @@ from .ops import Where
 __all__ = ["where"]
 
 
+@implements_numpy_override
 def where(
     condition: ArrayLike,
     x: ArrayLike = _NoValue,

--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.core.einsumfunc import _parse_einsum_input
 
 import mygrad as mg
-from mygrad import Tensor
+from mygrad.tensor_base import Tensor, implements_numpy_override
 from mygrad.typing import ArrayLike, DTypeLikeReals
 from mygrad.ufuncs import ufunc_creator
 
@@ -96,7 +96,7 @@ def matmul(
 
     Notes
     -----
-    The matmul function implements the semantics of the `@` operator introduced
+    The matmul function implements_numpy_override the semantics of the `@` operator introduced
     in Python 3.5 following PEP465.
 
     Examples
@@ -136,9 +136,11 @@ def matmul(
     ...
 
 
+@implements_numpy_override
 def einsum(
     *operands: Union[ArrayLike, str, Sequence[int]],
     optimize: bool = False,
+    out: Optional[Union[np.ndarray, Tensor]] = None,
     constant: Optional[bool] = None,
 ) -> Tensor:
     r"""
@@ -404,6 +406,7 @@ def einsum(
         *variables,
         op_kwargs=dict(in_lbls=in_lbls, out_lbls=out_lbls, optimize=optimize),
         constant=constant,
+        out=out,
     )
 
 

--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -96,7 +96,7 @@ def matmul(
 
     Notes
     -----
-    The matmul function implements_numpy_override the semantics of the `@` operator introduced
+    The matmul function implements the semantics of the `@` operator introduced
     in Python 3.5 following PEP465.
 
     Examples

--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -403,14 +403,13 @@ def einsum(
     in_lbls, out_lbls, _ = _parse_einsum_input(operands)
 
     # einsum doesn't handle out=None properly in numpy 1.17
-    kwargs = {} if out is None else {"out": out}
 
     return Tensor._op(
         EinSum,
         *variables,
         op_kwargs=dict(in_lbls=in_lbls, out_lbls=out_lbls, optimize=optimize),
         constant=constant,
-        **kwargs,
+        out=out,
     )
 
 

--- a/src/mygrad/linalg/funcs.py
+++ b/src/mygrad/linalg/funcs.py
@@ -401,12 +401,16 @@ def einsum(
             )
 
     in_lbls, out_lbls, _ = _parse_einsum_input(operands)
+
+    # einsum doesn't handle out=None properly in numpy 1.17
+    kwargs = {} if out is None else {"out": out}
+
     return Tensor._op(
         EinSum,
         *variables,
         op_kwargs=dict(in_lbls=in_lbls, out_lbls=out_lbls, optimize=optimize),
         constant=constant,
-        out=out,
+        **kwargs,
     )
 
 

--- a/src/mygrad/linalg/ops.py
+++ b/src/mygrad/linalg/ops.py
@@ -115,7 +115,7 @@ def _get_indices(item, seq):
 class EinSum(Operation):
     can_return_view = True
 
-    def __call__(self, *variables, in_lbls, out_lbls, optimize=False):
+    def __call__(self, *variables, in_lbls, out_lbls, out=None, optimize=False):
         """
         einsum('{in_lbls}->{out_lbls}', *variables, optimize=optimize)
 
@@ -142,7 +142,8 @@ class EinSum(Operation):
         return np.einsum(
             "->".join((in_lbls, out_lbls)),
             *(var.data for var in self.variables),
-            optimize=optimize
+            optimize=optimize,
+            out=out,
         )
 
     @property

--- a/src/mygrad/linalg/ops.py
+++ b/src/mygrad/linalg/ops.py
@@ -139,11 +139,14 @@ class EinSum(Operation):
         # fed to einsum. Only one gradient will be computed for a
         # unique tensor-label pair
         self._cache = None
+
+        # einsum doesn't handle out=None properly in numpy 1.17
+        kwargs = {} if out is None else {"out": out}
         return np.einsum(
             "->".join((in_lbls, out_lbls)),
             *(var.data for var in self.variables),
             optimize=optimize,
-            out=out,
+            **kwargs,
         )
 
     @property

--- a/src/mygrad/math/misc/funcs.py
+++ b/src/mygrad/math/misc/funcs.py
@@ -2,7 +2,7 @@ from typing import Optional, Union
 
 from numpy import ndarray
 
-from mygrad.tensor_base import Tensor
+from mygrad.tensor_base import Tensor, implements_numpy_override
 from mygrad.typing import ArrayLike, DTypeLikeReals, Mask
 from mygrad.ufuncs import ufunc_creator
 
@@ -403,6 +403,7 @@ def minimum(
     ...
 
 
+@implements_numpy_override
 def clip(a, a_min, a_max, *, constant=None):
     """Clip (limit) the values in an array.
 

--- a/src/mygrad/math/sequential/funcs.py
+++ b/src/mygrad/math/sequential/funcs.py
@@ -1,7 +1,13 @@
 from typing import Optional, Tuple, Union
 
+import numpy as np
+
 from mygrad.operation_base import _NoValue
-from mygrad.tensor_base import Tensor
+from mygrad.tensor_base import (
+    _REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS,
+    Tensor,
+    implements_numpy_override,
+)
 from mygrad.typing import ArrayLike
 
 from .ops import *
@@ -24,6 +30,7 @@ __all__ = [
 ]
 
 
+@implements_numpy_override
 def sum(
     x: ArrayLike,
     axis: Axis = None,
@@ -111,6 +118,7 @@ def sum(
     )
 
 
+@implements_numpy_override
 def mean(
     x: ArrayLike,
     axis: Axis = None,
@@ -187,6 +195,7 @@ def mean(
     )
 
 
+@implements_numpy_override
 def var(
     x: ArrayLike,
     axis: Axis = None,
@@ -282,6 +291,7 @@ def var(
     )
 
 
+@implements_numpy_override
 def std(
     x: ArrayLike,
     axis: Axis = None,
@@ -376,6 +386,7 @@ def std(
     )
 
 
+@implements_numpy_override
 def max(
     x: ArrayLike,
     axis: Axis = None,
@@ -440,6 +451,7 @@ def max(
     )
 
 
+@implements_numpy_override
 def min(
     x: ArrayLike,
     axis: Axis = None,
@@ -505,8 +517,11 @@ def min(
 # aliases
 amin = min
 amax = max
+_REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS[np.amin] = amin
+_REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS[np.amax] = amax
 
 
+@implements_numpy_override
 def prod(
     a: ArrayLike,
     axis: Axis = None,
@@ -577,6 +592,7 @@ def prod(
     )
 
 
+@implements_numpy_override
 def cumprod(
     a: ArrayLike, axis: Axis = None, *, constant: Optional[bool] = None
 ) -> Tensor:
@@ -641,6 +657,7 @@ def cumprod(
     return Tensor._op(CumProd, a, op_kwargs=dict(axis=axis), constant=constant)
 
 
+@implements_numpy_override
 def cumsum(
     a: ArrayLike, axis: Axis = None, *, constant: Optional[bool] = None
 ) -> Tensor:

--- a/src/mygrad/random/funcs.py
+++ b/src/mygrad/random/funcs.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 
 from mygrad import Tensor
-from mygrad.typing import ArrayLike, Shape
+from mygrad.typing import Shape
 
 
 def rand(*shape: int, constant: Optional[bool] = None) -> Tensor:

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -709,7 +709,7 @@ class Tensor:
                     for k, v in kwargs.items()
                 },
             )
-        else:
+        else:  # pragma: no cover
             return NotImplemented
 
     def __array__(self, dtype: DTypeLike = None) -> np.ndarray:

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -590,7 +590,7 @@ class Tensor:
     ) -> Union["Tensor", np.ndarray]:
         """An interface provided by NumPy to override the behavior of its ufuncs [1]_.
 
-        MyGrad implements_numpy_override its own ufuncs for all differentiable NumPy ufuncs.
+        MyGrad implements its own ufuncs for all differentiable NumPy ufuncs.
 
         Non-differentiable numpy ufuncs simply get called on the underlying arrays of tensors and
         will return ndarrays.

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -421,7 +421,7 @@ def implements_numpy_override(func: T) -> T:
 
     >>> import numpy as np
     >>> import mygrad as mg
-    >>> np.shape(mg.tensor(1.), 2)
+    >>> np.reshape(mg.tensor(1.), 2)
     'hello world'
 
     References

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -696,7 +696,9 @@ class Tensor:
                 f"{repr(ufunc)} cannot involve non-constant mygrad tensors."
             )
 
-    def __array_function__(self, func: Callable[..., np.ndarray], types, args, kwargs):
+    def __array_function__(
+        self, func: Callable[..., np.ndarray], types, args, kwargs
+    ) -> Union["Tensor", np.ndarray]:
         if func in _REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS:
             return _REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS[func](*args, **kwargs)
         elif func in _REGISTERED_NO_DIFF_NUMPY_FUNCS:

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1668,7 +1668,7 @@ class Tensor:
             graph.restore_old_graph()
             raise e
 
-        placeholder_mutant_view._constant |= inplace_target._constant
+        placeholder_mutant_view._constant = inplace_target._constant
 
         if _mem.MEM_GUARD:
             _mem.force_lock_tensor_and_creators(placeholder_mutant_view)

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -401,14 +401,10 @@ _REGISTERED_NO_DIFF_NUMPY_FUNCS: Set[Callable[..., np.ndarray]] = {
     np.bincount,
     np.can_cast,
     np.copyto,
-    np.empty_like,
-    np.full_like,
     np.may_share_memory,
     np.min_scalar_type,
-    np.ones_like,
     np.result_type,
     np.shares_memory,
-    np.zeros_like,
 }
 
 

--- a/src/mygrad/tensor_base.py
+++ b/src/mygrad/tensor_base.py
@@ -1666,6 +1666,8 @@ class Tensor:
             graph.restore_old_graph()
             raise e
 
+        placeholder_mutant_view._constant |= inplace_target._constant
+
         if _mem.MEM_GUARD:
             _mem.force_lock_tensor_and_creators(placeholder_mutant_view)
 

--- a/src/mygrad/tensor_creation/funcs.py
+++ b/src/mygrad/tensor_creation/funcs.py
@@ -2,10 +2,17 @@ from typing import Optional, Sequence, Union
 
 import numpy as np
 
-from mygrad.tensor_base import Tensor, _resolve_constant
+from mygrad.tensor_base import Tensor, _resolve_constant, implements_numpy_override
 from mygrad.typing import ArrayLike, DTypeLikeReals, Real
 
 Shape = Union[Sequence[int], int]
+
+
+def _anything_but_tensor(x):
+    if isinstance(x, Tensor):
+        x = x.data
+    return x
+
 
 __all__ = [
     "arange",
@@ -87,6 +94,7 @@ def empty(
     return Tensor(np.empty(shape=shape, dtype=dtype), constant=constant, copy=False)
 
 
+@implements_numpy_override
 def empty_like(
     other: ArrayLike,
     dtype: Optional[DTypeLikeReals] = None,
@@ -147,7 +155,9 @@ def empty_like(
     """
     constant = _resolve_constant(other, constant=constant)
     return Tensor(
-        np.empty_like(other, dtype=dtype, shape=shape), constant=constant, copy=False
+        np.empty_like(_anything_but_tensor(other), dtype=dtype, shape=shape),
+        constant=constant,
+        copy=False,
     )
 
 
@@ -319,6 +329,7 @@ def ones(
     return Tensor(np.ones(shape, dtype=dtype), constant=constant, copy=False)
 
 
+@implements_numpy_override
 def ones_like(
     other: ArrayLike,
     dtype: Optional[DTypeLikeReals] = None,
@@ -380,8 +391,11 @@ def ones_like(
     Tensor([ 1.,  1.,  1.])
     """
     constant = _resolve_constant(other, constant=constant)
+
     return Tensor(
-        np.ones_like(other, dtype=dtype, shape=shape), constant=constant, copy=False
+        np.ones_like(_anything_but_tensor(other), dtype=dtype, shape=shape),
+        constant=constant,
+        copy=False,
     )
 
 
@@ -446,6 +460,7 @@ def zeros(
     return Tensor(np.zeros(shape, dtype), constant=constant, copy=False)
 
 
+@implements_numpy_override
 def zeros_like(
     other: ArrayLike,
     dtype: Optional[DTypeLikeReals] = None,
@@ -516,7 +531,9 @@ def zeros_like(
     """
     constant = _resolve_constant(other, constant=constant)
     return Tensor(
-        np.zeros_like(other, dtype=dtype, shape=shape), constant=constant, copy=False
+        np.zeros_like(_anything_but_tensor(other), dtype=dtype, shape=shape),
+        constant=constant,
+        copy=False,
     )
 
 
@@ -583,6 +600,7 @@ def full(
     )
 
 
+@implements_numpy_override
 def full_like(
     other: ArrayLike,
     fill_value: Real,
@@ -643,8 +661,14 @@ def full_like(
     Tensor([ 0.1,  0.1,  0.1,  0.1,  0.1,  0.1])
     """
     constant = _resolve_constant(other, constant=constant)
+
     return Tensor(
-        np.full_like(other, fill_value=fill_value, dtype=dtype, shape=shape),
+        np.full_like(
+            _anything_but_tensor(other),
+            fill_value=_anything_but_tensor(fill_value),
+            dtype=dtype,
+            shape=shape,
+        ),
         constant=constant,
         copy=False,
     )

--- a/src/mygrad/tensor_manip/array_shape/funcs.py
+++ b/src/mygrad/tensor_manip/array_shape/funcs.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple, Union
 
-from mygrad.tensor_base import Tensor
+from mygrad.tensor_base import Tensor, implements_numpy_override
 from mygrad.typing import ArrayLike, Shape
 
 from .ops import *
@@ -8,6 +8,7 @@ from .ops import *
 __all__ = ["reshape", "squeeze", "ravel", "expand_dims", "broadcast_to"]
 
 
+@implements_numpy_override
 def reshape(
     a: ArrayLike, newshape: Union[int, Shape], *, constant: Optional[bool] = None
 ) -> Tensor:
@@ -55,6 +56,7 @@ def reshape(
     return Tensor._op(Reshape, a, op_args=(newshape,), constant=constant)
 
 
+@implements_numpy_override
 def squeeze(
     a: ArrayLike,
     axis: Optional[Union[int, Tuple[int, ...]]] = None,
@@ -108,6 +110,7 @@ def squeeze(
     return Tensor._op(Squeeze, a, op_args=(axis,), constant=constant)
 
 
+@implements_numpy_override
 def ravel(a: ArrayLike, *, constant: Optional[bool] = None) -> Tensor:
     """
     Flattens contents of a tensor into a contiguous 1-D array.  A copy is made only if needed.
@@ -144,6 +147,7 @@ def ravel(a: ArrayLike, *, constant: Optional[bool] = None) -> Tensor:
     return Tensor._op(Ravel, a, constant=constant)
 
 
+@implements_numpy_override
 def expand_dims(a: ArrayLike, axis: int, *, constant: Optional[bool] = None) -> Tensor:
     """
     Expand the dimensions of a tensor by adding a new axis.
@@ -182,6 +186,7 @@ def expand_dims(a: ArrayLike, axis: int, *, constant: Optional[bool] = None) -> 
     return Tensor._op(ExpandDims, a, op_args=(axis,), constant=constant)
 
 
+@implements_numpy_override
 def broadcast_to(
     a: ArrayLike, shape: Shape, *, constant: Optional[bool] = None
 ) -> Tensor:

--- a/src/mygrad/tensor_manip/tiling/funcs.py
+++ b/src/mygrad/tensor_manip/tiling/funcs.py
@@ -1,6 +1,6 @@
 from typing import Optional, Sequence, Union
 
-from mygrad.tensor_base import Tensor
+from mygrad.tensor_base import Tensor, implements_numpy_override
 from mygrad.typing import ArrayLike
 
 from .ops import Repeat
@@ -8,6 +8,7 @@ from .ops import Repeat
 __all__ = ["repeat"]
 
 
+@implements_numpy_override
 def repeat(
     a: ArrayLike,
     repeats: Union[int, Sequence[int]],

--- a/src/mygrad/tensor_manip/transpose_like/funcs.py
+++ b/src/mygrad/tensor_manip/transpose_like/funcs.py
@@ -1,6 +1,6 @@
 from typing import Optional, Tuple, Union
 
-from mygrad.tensor_base import Tensor
+from mygrad.tensor_base import Tensor, implements_numpy_override
 from mygrad.typing import ArrayLike
 
 from .ops import MoveAxis, Roll, SwapAxes, Transpose
@@ -8,6 +8,7 @@ from .ops import MoveAxis, Roll, SwapAxes, Transpose
 __all__ = ["transpose", "moveaxis", "swapaxes", "roll"]
 
 
+@implements_numpy_override
 def transpose(a: ArrayLike, *axes: int, constant: Optional[bool] = None) -> Tensor:
     """Permute the dimensions of a tensor.
 
@@ -62,6 +63,7 @@ def transpose(a: ArrayLike, *axes: int, constant: Optional[bool] = None) -> Tens
     return Tensor._op(Transpose, a, op_args=(axes,), constant=constant)
 
 
+@implements_numpy_override
 def moveaxis(
     a: ArrayLike,
     source: Union[int, Tuple[int, ...]],
@@ -112,6 +114,7 @@ def moveaxis(
     return Tensor._op(MoveAxis, a, op_args=(source, destination), constant=constant)
 
 
+@implements_numpy_override
 def swapaxes(
     a: ArrayLike, axis1: int, axis2: int, *, constant: Optional[bool] = None
 ) -> Tensor:
@@ -165,6 +168,7 @@ def swapaxes(
     return Tensor._op(SwapAxes, a, op_args=(axis1, axis2), constant=constant)
 
 
+@implements_numpy_override
 def roll(
     a: ArrayLike,
     shift: Union[int, Tuple[int, ...]],

--- a/tests/linalg/test_einsum.py
+++ b/tests/linalg/test_einsum.py
@@ -44,7 +44,8 @@ def compare_backprop(*operands, atol=1e-5, rtol=1e-5, optimize=False):
         def f(*args):
             return np.einsum(script, *args)
 
-        out = einsum(script, *tensors, optimize=optimize)
+        # tests override of numpy einsum when passed tensors
+        out = np.einsum(script, *tensors, optimize=optimize)
     else:
         # operands form: op0, sublist0, op1, sublist1, ..., [sublistout]
         end = -1 if len(operands) % 2 else None  # -1 if sublistout is included

--- a/tests/math/sequence/test_sequential_funcs.py
+++ b/tests/math/sequence/test_sequential_funcs.py
@@ -10,6 +10,7 @@ from pytest import raises
 
 import mygrad as mg
 from mygrad import amax, amin, cumprod, cumsum, mean, prod, std, sum, var
+from tests.utils.functools import add_constant_passthrough
 from tests.utils.numerical_gradient import numerical_gradient_full
 
 from ...custom_strategies import tensors, valid_axes
@@ -71,7 +72,7 @@ def test_max_no_graph_track_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=amax,
+    mygrad_func=add_constant_passthrough(np.amax),  # exercises __array_function__
     true_func=np.amax,
     num_arrays=1,
     kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
@@ -106,7 +107,7 @@ def test_min_no_graph_track_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=amin,
+    mygrad_func=add_constant_passthrough(np.amin),  # exercises __array_function__
     true_func=np.amin,
     num_arrays=1,
     kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
@@ -134,7 +135,7 @@ def test_sum_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=sum,
+    mygrad_func=add_constant_passthrough(np.sum),  # exercises __array_function__
     true_func=np.sum,
     num_arrays=1,
     kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
@@ -156,7 +157,7 @@ def test_mean_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=mean,
+    mygrad_func=add_constant_passthrough(np.mean),  # exercises __array_function__
     true_func=np.mean,
     num_arrays=1,
     kwargs=dict(axis=axis_arg, keepdims=keepdims_arg),
@@ -212,7 +213,7 @@ def test_custom_var_fwd():
 
 # test keepdims=True/False explicitly to deal with coverage issues
 @backprop_test_factory(
-    mygrad_func=var,
+    mygrad_func=add_constant_passthrough(np.var),  # exercises __array_function__,
     true_func=_var,
     num_arrays=1,
     kwargs=dict(axis=partial(axis_arg, min_dim=1), keepdims=False, ddof=ddof_arg),
@@ -224,7 +225,7 @@ def test_var_bkwd_without_keepdims():
 
 
 @backprop_test_factory(
-    mygrad_func=var,
+    mygrad_func=add_constant_passthrough(np.var),  # exercises __array_function__,,
     true_func=_var,
     num_arrays=1,
     kwargs=dict(axis=partial(axis_arg, min_dim=1), keepdims=True, ddof=ddof_arg),
@@ -256,7 +257,7 @@ def test_var_no_axis_fwd(x: mg.Tensor):
     )
 )
 def test_var_no_axis_bkwrd(x: mg.Tensor):
-    mg.var(x, axis=()).backward()
+    np.var(x, axis=()).backward()
     assert np.all(x.grad == mg.zeros_like(x))
 
 
@@ -310,7 +311,7 @@ def _assume(*arrs, **kwargs):
 
 
 @backprop_test_factory(
-    mygrad_func=std,
+    mygrad_func=add_constant_passthrough(np.std),  # exercises __array_function__,,
     true_func=_std,
     num_arrays=1,
     kwargs=dict(
@@ -374,7 +375,7 @@ def test_prod_bkwd():
 
 
 @backprop_test_factory(
-    mygrad_func=prod,
+    mygrad_func=add_constant_passthrough(np.prod),  # exercises __array_function__,,
     true_func=np.prod,
     num_arrays=1,
     elements_strategy=st.integers,
@@ -413,7 +414,7 @@ def test_cumprod_fwd():
 
 @settings(deadline=None)
 @backprop_test_factory(
-    mygrad_func=cumprod,
+    mygrad_func=add_constant_passthrough(np.cumprod),  # exercises __array_function__,
     true_func=np.cumprod,
     num_arrays=1,
     kwargs=dict(axis=single_axis_arg),
@@ -466,7 +467,7 @@ def test_cumsum_fwd():
 
 @settings(deadline=None)
 @backprop_test_factory(
-    mygrad_func=cumsum,
+    mygrad_func=add_constant_passthrough(np.cumsum),  # exercises __array_function__,,
     true_func=np.cumsum,
     num_arrays=1,
     kwargs=dict(axis=single_axis_arg),

--- a/tests/math/test_misc.py
+++ b/tests/math/test_misc.py
@@ -149,12 +149,12 @@ def is_not_close_clip(a: Tensor, a_min=None, a_max=None) -> bool:
     ("mygrad_clip", "numpy_clip", "num_arrays"),
     [
         (
-            partial(amin_clip_only, clip),
+            partial(amin_clip_only, np.clip),  # exercises __array_function__
             partial(amin_clip_only, np.clip, constant=None),
             2,
         ),
         (
-            partial(amax_clip_only, clip),
+            partial(amax_clip_only, np.clip),  # exercises __array_function__
             partial(amax_clip_only, np.clip, constant=None),
             2,
         ),

--- a/tests/tensor_ops/test_reshape.py
+++ b/tests/tensor_ops/test_reshape.py
@@ -10,6 +10,7 @@ from numpy.testing import assert_array_equal
 import mygrad as mg
 from mygrad import reshape
 from mygrad.tensor_base import Tensor
+from tests.utils.functools import add_constant_passthrough
 
 from ..custom_strategies import tensors, valid_shapes
 from ..wrappers.uber import backprop_test_factory, fwdprop_test_factory
@@ -211,7 +212,9 @@ def test_method_reshape_fwd(reshape_type):
 )
 def test_reshape_bkwd(reshape_type):
     @backprop_test_factory(
-        mygrad_func=partial(reshape_type, reshaper=reshape),
+        mygrad_func=partial(
+            reshape_type, reshaper=add_constant_passthrough(reshape)
+        ),  # exercises __array_function__
         true_func=partial(reshape_type, reshaper=np.reshape),
         num_arrays=1,
         kwargs=dict(newshape=lambda arrs: valid_shapes(arrs.size, min_len=0)),

--- a/tests/tensor_ops/test_setitem.py
+++ b/tests/tensor_ops/test_setitem.py
@@ -218,17 +218,19 @@ def test_setitem_sanity_check(x_constant, y_constant, data):
     assert isinstance(w, Tensor)
     assert_allclose(w.data, np.array([-1.0, 8.0, 0.0, 16.0]))
 
-    if not x.constant or (as_tensor and not y.constant):
+    if not w.constant:
+        assert w.grad is not None
         assert_allclose(w.grad, np.ones_like(w.data))
-    assert w.constant is (x.constant and (not as_tensor or y.constant))
+    assert w.constant is x.constant
 
     if x.constant:
+        pass
         assert x.grad is None
     else:
         assert_allclose(x.grad, np.array([0.0, 4.0, 0.0, 4.0]))
 
     if as_tensor:
-        if y.constant:
+        if w.constant or y.constant:
             assert y.grad is None
         else:
             assert_allclose(y.grad, np.array([-1.0, -2.0]))

--- a/tests/test_in_place_semantics.py
+++ b/tests/test_in_place_semantics.py
@@ -157,6 +157,19 @@ def test_raising_during_in_place_op_doesnt_corrupt_graph(inplace_on_view: bool):
     assert_allclose(x.grad, 4 * np.ones_like(y))
 
 
+@pytest.mark.parametrize("x_constant", [False, True])
+@pytest.mark.parametrize("y_constant", [False, True])
+@pytest.mark.parametrize("z_constant", [False, True])
+def test_inplace_update_constant_dictated_by_target(
+    x_constant: bool, y_constant: bool, z_constant: bool
+):
+    x = mg.tensor([1.0], constant=x_constant)
+    y = mg.tensor([1.0], constant=y_constant)
+    z = mg.tensor([1.0], constant=z_constant)
+
+    assert np.multiply(x, y, out=z).constant is z_constant
+
+
 @pytest.mark.parametrize("inplace_on_view", [False, True])
 @pytest.mark.parametrize("x_constant", [False, True])
 @pytest.mark.parametrize("y_constant", [False, True])

--- a/tests/test_in_place_semantics.py
+++ b/tests/test_in_place_semantics.py
@@ -160,7 +160,7 @@ def test_raising_during_in_place_op_doesnt_corrupt_graph(inplace_on_view: bool):
 @pytest.mark.parametrize("inplace_on_view", [False, True])
 @pytest.mark.parametrize("x_constant", [False, True])
 @pytest.mark.parametrize("y_constant", [False, True])
-def test_inplace_update_propagates_constant_info(
+def test_inplace_update_constant_dictated_by_target(
     inplace_on_view: bool, x_constant: bool, y_constant: bool
 ):
     x = mg.arange(1.0, 5.0, constant=x_constant)
@@ -175,7 +175,7 @@ def test_inplace_update_propagates_constant_info(
 
     x[...] = y
 
-    assert x.constant is (x_constant and y_constant)
+    assert x.constant is x_constant
     assert dangling_view.constant is x.constant
 
 

--- a/tests/test_in_place_semantics.py
+++ b/tests/test_in_place_semantics.py
@@ -528,7 +528,7 @@ def test_complicated_inplace_pattern2(x: Tensor, y: Tensor):
     assert x.data.flags.writeable
     assert diag_x.data.flags.writeable
 
-    grad_x = np.zeros_like(x)
+    grad_x = np.zeros_like(x.data)
 
     # dl/dx =
     # [2y0, y1, y2]

--- a/tests/test_indexing_routines.py
+++ b/tests/test_indexing_routines.py
@@ -13,7 +13,7 @@ def mygrad_where(x, y, condition, constant=None):
     return where(condition, x, y, constant=constant)
 
 
-def numpy_where(x, y, condition):
+def numpy_where(x, y, condition, constant=None):
     return np.where(condition, x, y)
 
 
@@ -33,7 +33,7 @@ def test_where_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=mygrad_where,
+    mygrad_func=numpy_where,  # exercises __array_function__ override
     true_func=numpy_where,
     kwargs=dict(condition=condition_strat),
     num_arrays=2,
@@ -51,7 +51,7 @@ def test_where_condition_only_fwd(condition):
         mg.Tensor(condition) if isinstance(condition, np.ndarray) else condition
     )
     assert all(
-        np.all(x == y) for x, y in zip(where(tensor_condition), np.where(condition))
+        np.all(x == y) for x, y in zip(np.where(tensor_condition), np.where(condition))
     )
 
 

--- a/tests/test_numpy_override.py
+++ b/tests/test_numpy_override.py
@@ -1,0 +1,31 @@
+import pytest
+
+from mygrad.tensor_base import (
+    _REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS,
+    _REGISTERED_NO_DIFF_NUMPY_FUNCS,
+    implements_numpy_override,
+)
+
+
+def test_override_on_non_numpy_function():
+    def not_a_numpy_function():
+        pass
+
+    with pytest.raises(AttributeError):
+        implements_numpy_override(not_a_numpy_function)
+
+
+@pytest.mark.parametrize(
+    "numpy_func",
+    sorted(_REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS, key=lambda x: x.__name__),
+)
+def test_registered_numpy_overrides_are_callables(numpy_func):
+    assert callable(numpy_func)
+    assert callable(_REGISTERED_DIFFERENTIABLE_NUMPY_FUNCS[numpy_func])
+
+
+@pytest.mark.parametrize(
+    "numpy_func", sorted(_REGISTERED_NO_DIFF_NUMPY_FUNCS, key=lambda x: x.__name__)
+)
+def test_registered_non_diff_numpy_overrides_are_callables(numpy_func):
+    assert callable(numpy_func)

--- a/tests/test_tensor_manip.py
+++ b/tests/test_tensor_manip.py
@@ -15,10 +15,10 @@ from mygrad import (
     ravel,
     repeat,
     roll,
-    squeeze,
     swapaxes,
     transpose,
 )
+from tests.utils.functools import add_constant_passthrough
 from tests.utils.wrappers import adds_constant_arg
 
 from .custom_strategies import valid_axes
@@ -143,10 +143,10 @@ def test_squeeze(x, data):
         numpy_out = np.squeeze(x, axes)
     except ValueError:
         with raises(ValueError):
-            squeeze(x_arr, axes, constant=False)
+            np.squeeze(x_arr, axes)
         return
 
-    o = squeeze(x_arr, axes, constant=False)
+    o = np.squeeze(x_arr, axes)  # exercises __array_function__
     o_method = x_arr2.squeeze(axes)
     assert_allclose(o.data, numpy_out)
     assert_allclose(o_method.data, numpy_out)
@@ -222,7 +222,7 @@ def test_transpose_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=_transpose,
+    mygrad_func=add_constant_passthrough(_np_transpose),  # exercises __array_function__
     true_func=_np_transpose,
     num_arrays=1,
     kwargs=dict(axes=lambda x: valid_axes(x.ndim, min_dim=x.ndim, max_dim=x.ndim)),
@@ -243,7 +243,9 @@ def test_expand_dims_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=expand_dims,
+    mygrad_func=add_constant_passthrough(
+        np.expand_dims
+    ),  # exercises __array_function__
     true_func=np.expand_dims,
     num_arrays=1,
     kwargs=dict(axis=_expand_dims_axis),
@@ -270,7 +272,7 @@ def test_moveaxis_fwd():
 
 @settings(deadline=None)
 @backprop_test_factory(
-    mygrad_func=moveaxis,
+    mygrad_func=add_constant_passthrough(np.moveaxis),  # exercises __array_function__
     true_func=np.moveaxis,
     num_arrays=1,
     kwargs=dict(
@@ -297,7 +299,7 @@ def test_swapaxes_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=swapaxes,
+    mygrad_func=add_constant_passthrough(np.swapaxes),  # exercises __array_function__
     true_func=np.swapaxes,
     num_arrays=1,
     kwargs=dict(axis1=_swap_axes_axis, axis2=_swap_axes_axis),
@@ -334,7 +336,10 @@ def test_ravel_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=ravel, true_func=np.ravel, num_arrays=1, vary_each_element=True
+    mygrad_func=add_constant_passthrough(np.ravel),  # exercises __array_function__
+    true_func=np.ravel,
+    num_arrays=1,
+    vary_each_element=True,
 )
 def test_ravel_bkwd():
     pass
@@ -354,7 +359,9 @@ def test_broadcast_to_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=broadcast_to,
+    mygrad_func=add_constant_passthrough(
+        np.broadcast_to
+    ),  # exercise __array_function__
     true_func=np.broadcast_to,
     num_arrays=1,
     vary_each_element=True,
@@ -394,7 +401,7 @@ def test_roll_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=roll,
+    mygrad_func=add_constant_passthrough(np.roll),  # exercises __array_function__
     true_func=np.roll,
     num_arrays=1,
     kwargs=gen_roll_args,
@@ -464,7 +471,7 @@ def test_repeat_tuple_repeats_only_fwd():
 
 
 @backprop_test_factory(
-    mygrad_func=repeat,
+    mygrad_func=add_constant_passthrough(np.repeat),  # exercises __array_function__
     true_func=np.repeat,
     num_arrays=1,
     kwargs=gen_tuple_repeat_args,

--- a/tests/ufuncs/test_fwd_prop_and_backprop.py
+++ b/tests/ufuncs/test_fwd_prop_and_backprop.py
@@ -257,7 +257,7 @@ def test_ufunc_bkwd(
     kwargs = args.kwargs.copy()
 
     # numerical grad needs to write complex-valued outputs
-    kwargs["out"] = np.zeros_like(mygrad_out, dtype=complex)
+    kwargs["out"] = np.zeros_like(mygrad_out.data, dtype=complex)
     numpy_ufunc = partial(getattr(np, ufunc.__name__), **kwargs)
 
     grads = numerical_gradient(numpy_ufunc, *args.args_as_no_mygrad(), back_grad=grad)

--- a/tests/utils/functools.py
+++ b/tests/utils/functools.py
@@ -1,5 +1,6 @@
 from collections import UserDict
 from copy import deepcopy
+from functools import wraps
 from typing import Any, Dict, Iterable, Sequence, Tuple, Union
 
 import numpy as np
@@ -17,6 +18,15 @@ def _make_read_only(item):
     elif isinstance(item, mg.Tensor):
         item.data.flags["WRITEABLE"] = False
     return
+
+
+def add_constant_passthrough(func):
+    @wraps(func)
+    def wrapped(*args, **kwargs):
+        kwargs.pop("constant", None)
+        return func(*args, **kwargs)
+
+    return wrapped
 
 
 class SmartSignature(UserDict):

--- a/tests/wrappers/test_uber.py
+++ b/tests/wrappers/test_uber.py
@@ -225,7 +225,7 @@ def test_catches_incorrect_op_gradient():
 
         def backward_var(self, grad, index, **kwargs):
             a = self.variables[index]
-            return grad * np.ones_like(a)  # should be: grad * 2 * np.ones_like(a)
+            return grad * np.ones_like(a.data)  # should be: grad * 2 * np.ones_like(a)
 
     def mul2_wrong_grad(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)
@@ -249,7 +249,7 @@ def test_catches_op_didnt_propagate_grad():
 
         def backward_var(self, grad, index, **kwargs):
             a = self.variables[index]
-            return 2 * np.ones_like(a)  # should be: grad * 2 * np.ones_like(a)
+            return 2 * np.ones_like(a.data)  # should be: grad * 2 * np.ones_like(a)
 
     def mul2_doesnt_prop_incoming_grad(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)
@@ -275,7 +275,7 @@ def test_catches_mutated_gradient():
 
         def backward_var(self, grad, index, **kwargs):
             a = self.variables[index]
-            grad *= 2 * np.ones_like(a)
+            grad *= 2 * np.ones_like(a.data)
             return grad
 
     def mul2_backprop_mutates_grad(x, constant=False):
@@ -303,7 +303,7 @@ def test_catches_backprop_mutated_input():
             a.data.flags.writeable = True
             a.data *= 3
             a.data.flags.writeable = False
-            return grad * 2 * np.ones_like(a)
+            return grad * 2 * np.ones_like(a.data)
 
     def mul2_backprop_mutates_input(x, constant=False):
         return Tensor._op(Mul2, x, constant=constant)


### PR DESCRIPTION
closes #220

The existing mygrad-mirrors for numpy functions now override those functions when they operate on a tensor:

```python
>>> x = mg.tensor([2., -1., 0.])
>>> numpy.einsum("i,i", x, x).backward()
>>> x.grad
array([ 4., -2.,  0.])
```