### PR TITLE
Adds mygrad.concatenate

### DIFF
--- a/docs/source/generated/mygrad.concatenate.rst
+++ b/docs/source/generated/mygrad.concatenate.rst
@@ -1,0 +1,6 @@
+mygrad.concatenate
+==================
+
+.. currentmodule:: mygrad
+
+.. autofunction:: concatenate

--- a/docs/source/tensor_manipulation.rst
+++ b/docs/source/tensor_manipulation.rst
@@ -35,8 +35,16 @@ Changing number of dimensions
    squeeze
 
 
-Tiling arrays
--------------
+Joining tensors
+---------------
+.. autosummary::
+   :toctree: generated/
+
+   concatenate
+
+
+Tiling tensors
+--------------
 .. autosummary::
    :toctree: generated/
 

--- a/src/mygrad/__init__.py
+++ b/src/mygrad/__init__.py
@@ -26,6 +26,7 @@ from mygrad.math.trigonometric.funcs import *
 from mygrad.nnet.layers.utils import sliding_window_view
 from mygrad.tensor_creation.funcs import *
 from mygrad.tensor_manip.array_shape.funcs import *
+from mygrad.tensor_manip.tensor_joining.funcs import *
 from mygrad.tensor_manip.tiling.funcs import *
 from mygrad.tensor_manip.transpose_like.funcs import *
 from mygrad.ufuncs._ufunc_creators import ufunc

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -203,7 +203,7 @@ class Operation(ABC):
                     backed_grad = backed_grad * self.where
 
                 backed_grad = self.grad_post_process_fn(backed_grad, var.shape)
-                # assert backed_grad.shape == var.shape, (backed_grad.shape, var.shape)
+                assert backed_grad.shape == var.shape, (backed_grad.shape, var.shape)
                 if var._grad is None:
                     backed_grad = (
                         np.copy(backed_grad)

--- a/src/mygrad/operation_base.py
+++ b/src/mygrad/operation_base.py
@@ -134,7 +134,7 @@ class Operation(ABC):
         ----------
         grad : numpy.ndarray
             The back-propagated total derivative with respect to the present
-            operation: dℒ/df. This will have the same shape as the result
+            operation: dℒ/df. This will have the same shape as f, the result
             of the forward pass.
 
         index : int
@@ -203,7 +203,7 @@ class Operation(ABC):
                     backed_grad = backed_grad * self.where
 
                 backed_grad = self.grad_post_process_fn(backed_grad, var.shape)
-                assert backed_grad.shape == var.shape
+                # assert backed_grad.shape == var.shape, (backed_grad.shape, var.shape)
                 if var._grad is None:
                     backed_grad = (
                         np.copy(backed_grad)

--- a/src/mygrad/tensor_manip/tensor_joining/funcs.py
+++ b/src/mygrad/tensor_manip/tensor_joining/funcs.py
@@ -1,0 +1,96 @@
+from typing import Optional, Sequence, Union
+
+from numpy import ndarray
+
+from mygrad.tensor_base import Tensor, implements_numpy_override
+from mygrad.typing import ArrayLike, DTypeLikeReals
+
+from .ops import Concatenate
+
+__all__ = ["concatenate"]
+
+
+@implements_numpy_override
+def concatenate(
+    tensors: Sequence[ArrayLike],
+    axis: Optional[int] = 0,
+    out: Optional[Union[ndarray, Tensor]] = None,
+    dtype: Optional[DTypeLikeReals] = None,
+    constant: Optional[bool] = None,
+) -> Tensor:
+    """
+    concatenate((t1, t2, ...), axis=0, out=None)
+
+    Join a sequence of tensors along an existing axis.
+
+    This docstring was adapted from that of numpy.concatenate [1]_
+
+    Parameters
+    ----------
+    tensors : Sequence[ArrayLike]
+        The tensors must have the same shape, except in the dimension
+        corresponding to `axis` (the first, by default).
+
+    axis : Optional[int]
+        The axis along which the tensors will be joined.  If axis is ``None``,
+        tensors are flattened before use.  Default is 0.
+
+    out : Optional[Union[ndarray, Tensor]]
+        If provided, the destination to place the result. The shape must be
+        correct, matching that of what concatenate would have returned if no
+        out argument were specified.
+
+    constant : Optional[bool]
+        If ``True``, this tensor is treated as a constant, and thus does not
+        facilitate back propagation (i.e. ``constant.grad`` will always return
+        ``None``).
+
+        Defaults to ``False`` for float-type data.
+        Defaults to ``True`` for integer-type data.
+
+        Integer-type tensors must be constant.
+
+    dtype : Optional[DTypeLikeReals]
+        If provided, the destination array will have this dtype. Cannot be provided
+        together with ``out``.
+
+        Requires numpy 1.20 or higher.
+
+    Returns
+    -------
+    res : Tensor
+        The concatenated tensor.
+
+    See Also
+    --------
+    stack : Stack a sequence of arrays along a new axis.
+    hstack : Stack arrays in sequence horizontally (column wise).
+    vstack : Stack arrays in sequence vertically (row wise).
+    dstack : Stack arrays in sequence depth wise (along third dimension).
+
+    References
+    ----------
+    .. [1] Retrieved from https://numpy.org/doc/stable/reference/generated/numpy.concatenate.html
+
+    Examples
+    --------
+    >>> import mygrad as mg
+    >>> a = mg.tensor([[1, 2], [3, 4]])
+    >>> b = mg.tensor([[5, 6]])
+    >>> mg.concatenate((a, b), axis=0)
+    Tensor([[1, 2],
+           [3, 4],
+           [5, 6]])
+    >>> mg.concatenate((a, b.T), axis=1)
+    Tensor([[1, 2, 5],
+           [3, 4, 6]])
+    >>> mg.concatenate((a, b), axis=None)
+    Tensor([1, 2, 3, 4, 5, 6])
+    """
+    return Tensor._op(
+        Concatenate,
+        *tensors,
+        op_kwargs={"axis": axis, "dtype": dtype},
+        constant=constant,
+        out=out,
+    )

--- a/src/mygrad/tensor_manip/tensor_joining/ops.py
+++ b/src/mygrad/tensor_manip/tensor_joining/ops.py
@@ -1,0 +1,60 @@
+from itertools import accumulate
+from typing import TYPE_CHECKING, Optional
+
+import numpy as np
+
+from mygrad._utils.graph_tracking import TRACK_GRAPH
+from mygrad.operation_base import Operation
+
+if TYPE_CHECKING:  # pragma: no cover
+    from mygrad import Tensor
+
+__all__ = ["Concatenate"]
+
+
+class Concatenate(Operation):
+    def __call__(
+        self,
+        *input_vars: "Tensor",
+        axis: Optional[int] = 0,
+        out: Optional[np.ndarray] = None,
+        dtype=None,
+    ) -> np.ndarray:
+        kwargs = {"out": out, "axis": axis}
+        if dtype is not None:
+            # compatibility shim: min numpy 1.20
+            kwargs["dtype"] = dtype
+
+        out = np.concatenate(tuple(var.data for var in input_vars), **kwargs)
+
+        if TRACK_GRAPH:
+            self.axis = axis
+            self.variables = tuple(input_vars)
+            if axis is not None:
+                # need to make sure axis is non-negative so that
+                # axis checking during backprop is simplified
+                self.axis = axis % out.ndim
+                self.indices = list(
+                    accumulate([var.data.shape[axis] for var in input_vars])
+                )
+                self.indices.insert(0, 0)
+            else:
+                # inputs were flattened
+                self.indices = np.cumsum((0,) + tuple(var.size for var in input_vars))
+        return out
+
+    def backward_var(self, grad, index, **kwargs) -> np.ndarray:
+        var = self.variables[index]
+        if self.axis is None:
+            return grad[self.indices[index] : self.indices[index + 1]].reshape(
+                var.shape
+            )
+
+        return grad[
+            tuple(
+                slice(None, None, None)
+                if dim != self.axis
+                else slice(self.indices[index], self.indices[index + 1])
+                for dim in range(var.data.ndim)
+            )
+        ]

--- a/tests/test_tensor_joining.py
+++ b/tests/test_tensor_joining.py
@@ -1,0 +1,109 @@
+from functools import partial
+from typing import Optional, Tuple
+
+import hypothesis.extra.numpy as hnp
+import hypothesis.strategies as st
+import numpy as np
+import pytest
+from hypothesis import given
+from numpy.testing import assert_array_equal
+
+import mygrad as mg
+from mygrad.typing import ArrayLike
+from tests.custom_strategies import array_likes, tensors
+
+
+@st.composite
+def concatable_tensors(
+    draw, array_like_strat=array_likes
+) -> st.SearchStrategy[Tuple[Tuple[ArrayLike, ...], Optional[int]]]:
+    """draws valid inputs for numpy.concatenate"""
+    axis_is_none = draw(st.booleans())
+    if axis_is_none:
+        inputs = draw(
+            st.lists(
+                array_like_strat(
+                    shape=hnp.array_shapes(
+                        min_dims=0, min_side=0, max_dims=3, max_side=3
+                    ),
+                    dtype=float,
+                    elements=st.floats(-100, 100),
+                ),
+                min_size=1,
+                max_size=3,
+            ).map(tuple)
+        )
+        return inputs, None
+
+    master_shape: list = draw(hnp.array_shapes(min_dims=1, min_side=0).map(list))
+    N = len(master_shape) + 1
+    axis = draw(st.integers(-N, N - 1))
+    pos_axis = axis % N
+    shapes = []
+    for size in draw(st.lists(st.integers(1, 3), min_size=1, max_size=4)):
+        shape = master_shape.copy()
+        shape.insert(pos_axis, size)
+        shapes.append(shape)
+
+    concatable_arrs = st.tuples(
+        *(
+            array_like_strat(shape=shape, dtype=float, elements=st.floats(-100, 100))
+            for shape in shapes
+        )
+    )
+    return draw(concatable_arrs), axis
+
+
+@given(concatable_tensors(hnp.arrays))
+def test_concatable_tensors_strat(x: Tuple[Tuple[ArrayLike, ...], Optional[int]]):
+    """Ensures strat does not produce bad results"""
+    arrs, axis = x
+    np.concatenate(arrs, axis=axis)
+
+
+def not_tensor(x):
+    return x if not isinstance(x, mg.Tensor) else x.data
+
+
+@given(concatable_tensors(array_likes))
+def test_concatenate_fwd(x: Tuple[Tuple[ArrayLike, ...], Optional[int]]):
+    arrs, axis = x
+    mygrad_out = mg.concatenate(arrs, axis=axis)
+
+    # `not_tensor` ensures that mygrad override doesn't take place here
+    numpy_out = np.concatenate(tuple(not_tensor(x) for x in arrs), axis=axis)
+    assert isinstance(mygrad_out, mg.Tensor)
+    assert (
+        mygrad_out.base is None and numpy_out.base is None
+    ), "concatenate returns a view"
+    assert_array_equal(mygrad_out, numpy_out)
+
+
+@given(concatable_tensors(partial(tensors, constant=False)))
+def test_concatenate_bkwd(x: Tuple[Tuple[ArrayLike, ...], Optional[int]]):
+    arrs, axis = x
+    mygrad_out = np.concatenate(
+        arrs, axis=axis
+    )  # exercises __array_function__ override
+    mygrad_out.backward(mygrad_out.data)
+    for n, t in enumerate(arrs):
+        assert_array_equal(t.grad, t.data), f"tensor {n}"
+
+
+def test_concatenate_with_dtype():
+    if np.__version__ < "1.20":
+        pytest.skip("concatenate does not support dtype until numpy 1.20")
+    x = mg.tensor([1.0, 2.0])
+    assert mg.concatenate([x, x], dtype="float32").dtype == np.float32
+
+
+def test_concatenate_with_inplace_target():
+    if np.__version__ < "1.20":
+        pytest.skip("concatenate does not support dtype until numpy 1.20")
+    x = mg.tensor([1.0, 2.0])
+    y = mg.empty((4,))
+    np.concatenate([x, x], out=y)
+    y.backward()
+
+    assert_array_equal(x.grad, [2.0, 2.0])
+    assert_array_equal(y, mg.concatenate([x, x]))

--- a/tests/test_tensor_joining.py
+++ b/tests/test_tensor_joining.py
@@ -40,7 +40,7 @@ def concatable_tensors(
     axis = draw(st.integers(-N, N - 1))
     pos_axis = axis % N
     shapes = []
-    for size in draw(st.lists(st.integers(1, 3), min_size=1, max_size=4)):
+    for size in draw(st.lists(st.integers(0, 3), min_size=1, max_size=4)):
         shape = master_shape.copy()
         shape.insert(pos_axis, size)
         shapes.append(shape)

--- a/tests/test_tensor_joining.py
+++ b/tests/test_tensor_joining.py
@@ -98,8 +98,6 @@ def test_concatenate_with_dtype():
 
 
 def test_concatenate_with_inplace_target():
-    if np.__version__ < "1.20":
-        pytest.skip("concatenate does not support dtype until numpy 1.20")
     x = mg.tensor([1.0, 2.0])
     y = mg.empty((4,))
     np.concatenate([x, x], out=y)


### PR DESCRIPTION
Co-authored-by: Petar Griggs <petargriggs@gmail.com>

![image](https://user-images.githubusercontent.com/29104956/110216865-89a26600-7e7f-11eb-8895-91e583c2752d.png)


```python
>>> import mygrad as mg
>>> x = mg.tensor([[2., -1., 0.]], constant=False)
>>> o = np.concatenate([x, x, x], axis=0)
>>> o
Tensor([[ 2., -1.,  0.],
        [ 2., -1.,  0.],
        [ 2., -1.,  0.]])

>>> o.backward()
>>> x.grad
array([[3., 3., 3.]])
```

I plan to add the other joining functions in separate PRs